### PR TITLE
Init job permissions

### DIFF
--- a/internal/controllers/provider/install/rbac_init.go
+++ b/internal/controllers/provider/install/rbac_init.go
@@ -42,7 +42,7 @@ func newInitClusterRoleMutator(values *Values) resources.Mutator[*rbac.ClusterRo
 			{
 				APIGroups: []string{""},
 				Resources: []string{"secrets"},
-				Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+				Verbs:     []string{"get", "list", "watch"},
 			},
 			{
 				APIGroups: []string{"clusters.openmcp.cloud"},


### PR DESCRIPTION
**What this PR does / why we need it**:

Defines the permissions of the init job of a provider.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
- Allow init job of a provider to read and write ClusterRequests, AccessRequests, Secrets
```
