### PR TITLE
fix: prevent removing clusterRef or requestRef from AccessRequest

### DIFF
--- a/api/clusters/v1alpha1/accessrequest_types.go
+++ b/api/clusters/v1alpha1/accessrequest_types.go
@@ -5,6 +5,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.clusterRef) || has(self.clusterRef)", message="clusterRef may not be removed once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.requestRef) || has(self.requestRef)", message="requestRef may not be removed once set"
 type AccessRequestSpec struct {
 	// ClusterRef is the reference to the Cluster for which access is requested.
 	// If set, requestRef will be ignored.

--- a/api/crds/manifests/clusters.openmcp.cloud_accessrequests.yaml
+++ b/api/crds/manifests/clusters.openmcp.cloud_accessrequests.yaml
@@ -155,6 +155,11 @@ spec:
             required:
             - permissions
             type: object
+            x-kubernetes-validations:
+            - message: clusterRef may not be removed once set
+              rule: '!has(oldSelf.clusterRef) || has(self.clusterRef)'
+            - message: requestRef may not be removed once set
+              rule: '!has(oldSelf.requestRef) || has(self.requestRef)'
           status:
             description: AccessRequestStatus defines the observed state of AccessRequest
             properties:


### PR DESCRIPTION
**What this PR does / why we need it**:
Both, `spec.clusterRef` and `spec.requestRef` are meant to be immutable and cannot be removed after being set once. The first part was correctly enforced by CRD validation rules, the latter one was not. This PR fixes that.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
CRD validation now prevents both `spec.clusterRef` and `spec.requestRef` from being removed once they are set.
```
