### PR TITLE
feat: add apiserver endpoint to generic Cluster status

### DIFF
--- a/api/clusters/v1alpha1/cluster_types.go
+++ b/api/clusters/v1alpha1/cluster_types.go
@@ -57,6 +57,10 @@ type ClusterStatus struct {
 	// Phase is the current phase of the cluster.
 	Phase ClusterPhase `json:"phase"`
 
+	// APIServer is the API server endpoint of the cluster.
+	// +optional
+	APIServer string `json:"apiServer,omitempty"`
+
 	// ProviderStatus is the provider-specific status of the cluster.
 	// x-kubernetes-preserve-unknown-fields: true
 	// +optional

--- a/api/crds/manifests/clusters.openmcp.cloud_clusters.yaml
+++ b/api/crds/manifests/clusters.openmcp.cloud_clusters.yaml
@@ -122,6 +122,9 @@ spec:
           status:
             description: ClusterStatus defines the observed state of Cluster
             properties:
+              apiServer:
+                description: APIServer is the API server endpoint of the cluster.
+                type: string
               conditions:
                 description: Conditions contains the conditions.
                 items:


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The `Cluster` resource status has now a field `apiServer` that holds the apiserver endpoint for that cluster.
```
