### PR TITLE
refactor: do not use auto generated namespace with cluster manager

### DIFF
--- a/lib/clusteraccess/clusteraccess.go
+++ b/lib/clusteraccess/clusteraccess.go
@@ -323,6 +323,7 @@ func NewClusterAccessManager(platformClusterClient client.Client, controllerName
 	return &managerImpl{
 		platformClusterClient: platformClusterClient,
 		controllerName:        controllerName,
+		controllerNamespace:   controllerNamespace,
 		timeout:               5 * time.Minute,
 		interval:              10 * time.Second,
 		log:                   nil, // Default to no logging

--- a/lib/clusteraccess/clusteraccess_test.go
+++ b/lib/clusteraccess/clusteraccess_test.go
@@ -281,30 +281,32 @@ var _ = Describe("ClusterAccessReconciler", func() {
 
 var _ = Describe("ClusterAccessManager", func() {
 	It("should create and wait for onboarding cluster access", func() {
+
 		const (
-			clusterName    = "onboarding-cluster"
-			controllerName = "test-controller"
-			timeout        = 1 * time.Second
-			interval       = 20 * time.Millisecond
+			clusterName         = "onboarding-cluster"
+			controllerName      = "test-controller"
+			controllerNamespace = "test-namespace"
+			timeout             = 1 * time.Second
+			interval            = 20 * time.Millisecond
 		)
 
 		clusterRequest := &clustersv1alpha1.ClusterRequest{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      clusterName,
-				Namespace: utils.StableControllerNamespace(controllerName),
+				Namespace: controllerNamespace,
 			},
 		}
 
 		accessRequest := &clustersv1alpha1.AccessRequest{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      clusterName,
-				Namespace: utils.StableControllerNamespace(controllerName),
+				Namespace: controllerNamespace,
 			},
 		}
 
 		env := buildTestEnvironmentNoReconcile("test-03", accessRequest, clusterRequest)
 
-		manager := clusteraccess.NewClusterAccessManager(env.Client(), controllerName)
+		manager := clusteraccess.NewClusterAccessManager(env.Client(), controllerName, controllerNamespace)
 		Expect(manager).ToNot(BeNil(), "should create a ClusterAccessManager")
 
 		manager.WithInterval(interval).WithTimeout(timeout)

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -12,11 +12,6 @@ const (
 	prefixWorkload   = "wl-"
 )
 
-// StableControllerNamespace returns a stable namespace for controllers that can be used on the platform cluster.
-func StableControllerNamespace(controllerName string) string {
-	return fmt.Sprint(controller.K8sNameHash(controllerName), "-system")
-}
-
 // StableRequestNamespace returns a stable namespace for ClusterRequests and AccessRequests,
 // that can be created/used on the platform cluster.
 // onboardingNamespace is the namespace of the reconciled resource on the onboarding cluster.

--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -22,14 +22,6 @@ func TestUtils(t *testing.T) {
 }
 
 var _ = Describe("Utils", func() {
-	Context("StableControllerNamespace", func() {
-		It("should return a stable namespace for controllers", func() {
-			expectedNamespace := fmt.Sprint("x33lfeffopjdj5decdwbrcje75inbmpthligzyqlvvooqay7tpoq", "-system")
-
-			Expect(utils.StableControllerNamespace(controllerName)).To(Equal(expectedNamespace))
-		})
-	})
-
 	Context("StableRequestNamespace", func() {
 		It("should return a stable namespace for requests", func() {
 			expectedNamespace := "ob-foo"


### PR DESCRIPTION
**What this PR does / why we need it**:

Since the openmcp-operator deployer now passes the name of the namespace for a provider, it is no longer necessary to create a namespace on the fly in the the cluster manager.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
ClusterManager no longer auto generates a namespace
```
