### PR TITLE
fix: use correct permissions in workload access request

### DIFF
--- a/lib/clusteraccess/clusteraccess.go
+++ b/lib/clusteraccess/clusteraccess.go
@@ -240,7 +240,7 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, request reconcile.Reques
 				Name: requestNameWorkload,
 			},
 			Namespace: requestNamespace,
-		}, nil, r.mcpPermissions, metadata)
+		}, nil, r.workloadPermissions, metadata)
 
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to create or update Workload AccessRequest: %w", err)


### PR DESCRIPTION
**What this PR does / why we need it**:

The wrong permission variable was used in the access request for the workload cluster.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Use correct permissions in workload access request
```
