### PR TITLE
add common api package

### DIFF
--- a/api/common/reference_types.go
+++ b/api/common/reference_types.go
@@ -1,0 +1,26 @@
+package common
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	apimachinery "k8s.io/apimachinery/pkg/types"
+)
+
+// ObjectReference is a reference to an object in any namespace.
+type ObjectReference apimachinery.NamespacedName
+
+// LocalObjectReference is a reference to an object in the same namespace as the resource referencing it.
+type LocalObjectReference corev1.LocalObjectReference
+
+// SecretReference is a reference to a secret in any namespace with a key.
+type SecretReference struct {
+	ObjectReference `json:",inline"`
+	// Key is the key in the secret to use.
+	Key string `json:"key"`
+}
+
+// LocalSecretReference is a reference to a secret in the same namespace as the resource referencing it with a key.
+type LocalSecretReference struct {
+	LocalObjectReference `json:",inline"`
+	// Key is the key in the secret to use.
+	Key string `json:"key"`
+}

--- a/api/common/status_types.go
+++ b/api/common/status_types.go
@@ -1,0 +1,25 @@
+package common
+
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+const (
+	// StatusPhaseReady indicates that the resource is ready. All conditions are met and are in status "True".
+	StatusPhaseReady = "Ready"
+	// StatusPhaseProgressing indicates that the resource is not ready and being created or updated. At least one condition is not met and is in status "False".
+	StatusPhaseProgressing = "Progressing"
+	// StatusPhaseTerminating indicates that the resource is not ready and in deletion. At least one condition is not met and is in status "False".
+	StatusPhaseTerminating = "Terminating"
+)
+
+// Status represents the status of an openMCP resource.
+type Status struct {
+	// ObservedGeneration is the generation of this resource that was last reconciled by the controller.
+	ObservedGeneration int64 `json:"observedGeneration"`
+
+	// Phase is the current phase of the resource.
+	Phase string `json:"phase"`
+
+	// Conditions contains the conditions.
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a `common` api package with structs that can be reused across multiple projects in the openmcp org.

**Which issue(s) this PR fixes**:
Part of #70 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
There is a new `api/common` package with types that can be reused by multiple controllers. It currently contains a `Status` type as well as types for object and secret references.
```
