### PR TITLE
fix ObjectReference common struct

### DIFF
--- a/api/common/reference_types.go
+++ b/api/common/reference_types.go
@@ -5,8 +5,16 @@ import (
 	apimachinery "k8s.io/apimachinery/pkg/types"
 )
 
+// ClusterScoped can be passed into a LocalObjectReference's NamespacedName method to indicate that the object is cluster-scoped.
+const ClusterScoped = ""
+
 // ObjectReference is a reference to an object in any namespace.
-type ObjectReference apimachinery.NamespacedName
+type ObjectReference struct {
+	// Name is the name of the object.
+	Name string `json:"name"`
+	// Namespace is the namespace of the object.
+	Namespace string `json:"namespace"`
+}
 
 // LocalObjectReference is a reference to an object in the same namespace as the resource referencing it.
 type LocalObjectReference corev1.LocalObjectReference
@@ -23,4 +31,25 @@ type LocalSecretReference struct {
 	LocalObjectReference `json:",inline"`
 	// Key is the key in the secret to use.
 	Key string `json:"key"`
+}
+
+// NamespacedName returns the NamespacedName of the ObjectReference.
+// This is a convenience method to convert the ObjectReference to a NamespacedName, which can be passed into k8s client methods.
+func (r *ObjectReference) NamespacedName() apimachinery.NamespacedName {
+	return apimachinery.NamespacedName{
+		Name:      r.Name,
+		Namespace: r.Namespace,
+	}
+}
+
+// NamespacedName returns the NamespacedName of the LocalObjectReference.
+// This is a convenience method to convert the LocalObjectReference to a NamespacedName, which can be passed into k8s client methods.
+// Since LocalObjectReference refers to an object in the same namespace as the resource referencing it,
+// which is only known from context, this method requires a namespace parameter.
+// An empty string (or the ClusterScoped constant) can be used to indicate that the object is cluster-scoped.
+func (r *LocalObjectReference) NamespacedName(namespace string) apimachinery.NamespacedName {
+	return apimachinery.NamespacedName{
+		Name:      r.Name,
+		Namespace: namespace,
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
We initially wanted to use the `NamespacedName` struct from the `k8s.io/apimachinery/pkg/types` package as common object reference struct. However, since the aforementioned type is not defined with json tags, it cannot be embedded in k8s resource types

We therefore designed our own type instead.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Replaced the broken `ObjectReference` type from the `api/common` package with a working implementation.
```
