### PR TITLE
fix(panic): empty `AccessRequestConfig` during controller start up

### DIFF
--- a/cmd/openmcp-operator/app/run.go
+++ b/cmd/openmcp-operator/app/run.go
@@ -68,7 +68,7 @@ func NewRunCommand(so *SharedOptions) *cobra.Command {
 func (o *RunOptions) AddFlags(cmd *cobra.Command) {
 	// kubebuilder default flags
 	cmd.Flags().StringVar(&o.MetricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
-	cmd.Flags().StringVar(&o.ProbeAddr, "health-probe-bind-address", ":8082", "The address the probe endpoint binds to.")
+	cmd.Flags().StringVar(&o.ProbeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	cmd.Flags().StringVar(&o.PprofAddr, "pprof-bind-address", "", "The address the pprof endpoint binds to. Expected format is ':<port>'. Leave empty to disable pprof endpoint.")
 	cmd.Flags().BoolVar(&o.EnableLeaderElection, "leader-elect", false, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	cmd.Flags().BoolVar(&o.SecureMetrics, "metrics-secure", true, "If set, the metrics endpoint is served securely via HTTPS. Use --metrics-secure=false to use HTTP instead.")


### PR DESCRIPTION
**What this PR does / why we need it**:
This small PR fixes a bug that occurred while testing the openmcp-operator during local development.
It can happen that `AccessRequestConfig` can be nil and during start up of the accessrequest controller a developer might face a nil pointer dereference.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Fixing possible nil pointer dereference bug while accessing empty `AccessRequestConfig` during start up of accessrequest controller
```
