### PR TITLE
feat: args and envs

### DIFF
--- a/api/constants/constants.go
+++ b/api/constants/constants.go
@@ -22,10 +22,16 @@ const (
 	// OnboardingNamespaceLabel is used to store the namespace on the onboarding cluster of a resource.
 	OnboardingNamespaceLabel = OpenMCPGroupName + "/onboarding-namespace"
 
-	// EnvVariableProviderName is the name of an environment variable passed to providers.
-	// It contains the name of the provider resource.
-	EnvVariableProviderName = "OPENMCP_PROVIDER_NAME"
-	// EnvVariablePlatformClusterNamespace is the name of an environment variable passed to providers.
-	// It contains the namespace on the platform cluster in which the provider is running.
-	EnvVariablePlatformClusterNamespace = "OPENMCP_PLATFORM_CLUSTER_NAMESPACE"
+	// EnvVariablePodName is the name of an environment variable passed to providers.
+	// Its value is the name of the pod in which the provider is running.
+	EnvVariablePodName = "POD_NAME"
+	// EnvVariablePodNamespace is the name of an environment variable passed to providers.
+	// Its value is the namespace of the pod in which the pod is running.
+	EnvVariablePodNamespace = "POD_NAMESPACE"
+	// EnvVariablePodIP is the name of an environment variable passed to providers.
+	// Its value is the IP address of the pod in which the provider is running.
+	EnvVariablePodIP = "POD_IP"
+	// EnvVariablePodServiceAccountName is the name of an environment variable passed to providers.
+	// Its value is the name of the service account under which the pod is running.
+	EnvVariablePodServiceAccountName = "POD_SERVICE_ACCOUNT_NAME"
 )

--- a/docs/controller/deployment.md
+++ b/docs/controller/deployment.md
@@ -10,12 +10,15 @@ The deployments are specified in kubernetes resources of the kinds `ClusterProvi
 
 ## Provider Image
 
-To be deployable, each provider must have an image available in a container registry. The image must have an executable as entrypoint. It will be used twice: to initialize the provider and to run it. For the initialization, a Job is started with the executable, and the following arguments are supplied:
+To be deployable, each provider must have an image available in a container registry. The image must have an executable 
+as entrypoint. It will be used twice: to initialize the provider and to run it. For the initialization, a Job is started 
+with the executable, and the following arguments are supplied:
 
 ```shell
 init
 --environment <environment>
---verbosity <DEBUG, INFO, or ERROR>
+--verbosity <DEBUG|INFO|ERROR>
+--provider-name <name of the ClusterProvider|ServiceProvider|PlatformService resource>
 ```
 
 Once the initialization job has completed, a Deployment is created/updated with the same image and the following arguments:
@@ -24,6 +27,7 @@ Once the initialization job has completed, a Deployment is created/updated with 
 run
 --environment <environment>
 --verbosity <DEBUG|INFO|ERROR>
+--provider-name <name of the ClusterProvider|ServiceProvider|PlatformService resource>,
 ```
 
 ### Env Variables
@@ -32,8 +36,10 @@ The environment variables below are available in the pods of the init job and th
 
 - the environment variables specified in the [provider resource](#provider-resource), in field `spec.env`;
 - the following predefined environment variables:
-  - `OPENMCP_PROVIDER_NAME`: the name of the provider resource;
-  - `OPENMCP_PLATFORM_CLUSTER_NAMESPACE`: the namespace on the platform cluster in which the provider is running.
+  - `POD_NAME`: the name of the pod in which the provider is running,
+  - `POD_NAMESPACE`: the namespace of the pod in which the pod is running,
+  - `POD_IP`: the IP address of the pod in which the provider is running,
+  - `POD_SERVICE_ACCOUNT_NAME`: the name of the service account under which the pod is running.
 
 
 ## Provider Resource

--- a/internal/controllers/provider/controller_test.go
+++ b/internal/controllers/provider/controller_test.go
@@ -64,7 +64,8 @@ var _ = Describe("Deployment Controller", func() {
 			Expect(job.Spec.Template.Spec.Containers[0].Args).To(ContainElement("init"), "Job container args should contain the init command")
 			Expect(job.Spec.Template.Spec.Containers[0].Args).To(ContainElement("--environment=test-environment"), "Job container args should contain the environment")
 			Expect(job.Spec.Template.Spec.Containers[0].Args).To(ContainElement("--verbosity=DEBUG"), "Job container args should contain the verbosity")
-			Expect(job.Spec.Template.Spec.Containers[0].Env).To(HaveLen(3), "Job container should have an environment variables")
+			Expect(job.Spec.Template.Spec.Containers[0].Args).To(ContainElement("--provider-name="+req.Name), "Job container args should contain the provider name")
+			Expect(job.Spec.Template.Spec.Containers[0].Env).To(HaveLen(5), "Job container should have an environment variables")
 			Expect(job.Spec.Template.Spec.Containers[0].Env[0].Name).To(Equal("NAME"), "Job container environment variable name should match the provider spec")
 			Expect(job.Spec.Template.Spec.Containers[0].Env[0].Value).To(Equal("test-name"), "Job container environment variable value should match the provider spec")
 
@@ -82,7 +83,8 @@ var _ = Describe("Deployment Controller", func() {
 			Expect(deploy.Spec.Template.Spec.Containers[0].Args).To(ContainElement("run"), "Deployment container args should contain the run command")
 			Expect(deploy.Spec.Template.Spec.Containers[0].Args).To(ContainElement("--environment=test-environment"), "Deployment container args should contain the environment")
 			Expect(deploy.Spec.Template.Spec.Containers[0].Args).To(ContainElement("--verbosity=DEBUG"), "Deployment container args should contain the verbosity")
-			Expect(deploy.Spec.Template.Spec.Containers[0].Env).To(HaveLen(3), "Deployment container should have an environment variables")
+			Expect(deploy.Spec.Template.Spec.Containers[0].Args).To(ContainElement("--provider-name="+req.Name), "Deployment container args should contain the provider name")
+			Expect(deploy.Spec.Template.Spec.Containers[0].Env).To(HaveLen(5), "Deployment container should have an environment variables")
 			Expect(deploy.Spec.Template.Spec.Containers[0].Env[0].Name).To(Equal("NAME"), "Deployment container environment variable name should match the provider spec")
 			Expect(deploy.Spec.Template.Spec.Containers[0].Env[0].Value).To(Equal("test-name"), "Deployment container environment variable value should match the provider spec")
 

--- a/internal/controllers/provider/install/deployment.go
+++ b/internal/controllers/provider/install/deployment.go
@@ -73,6 +73,7 @@ func (m *deploymentMutator) Mutate(d *appsv1.Deployment) error {
 							"run",
 							"--environment=" + m.values.Environment(),
 							"--verbosity=" + m.values.Verbosity(),
+							"--provider-name=" + m.values.provider.GetName(),
 						},
 						Env: env,
 					},

--- a/internal/controllers/provider/install/job.go
+++ b/internal/controllers/provider/install/job.go
@@ -76,6 +76,7 @@ func (m *jobMutator) Mutate(j *v1.Job) error {
 							"init",
 							"--environment=" + m.values.Environment(),
 							"--verbosity=" + m.values.Verbosity(),
+							"--provider-name=" + m.values.provider.GetName(),
 						},
 						Env: env,
 					},

--- a/internal/controllers/provider/install/values.go
+++ b/internal/controllers/provider/install/values.go
@@ -112,8 +112,30 @@ func (v *Values) Verbosity() string {
 func (v *Values) EnvironmentVariables() ([]corev1.EnvVar, error) {
 	varList := append(
 		v.providerEnvironmentVariables(),
-		corev1.EnvVar{Name: constants.EnvVariableProviderName, Value: v.provider.GetName()},
-		corev1.EnvVar{Name: constants.EnvVariablePlatformClusterNamespace, Value: v.namespace},
+		corev1.EnvVar{
+			Name: constants.EnvVariablePodName,
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
+			},
+		},
+		corev1.EnvVar{
+			Name: constants.EnvVariablePodNamespace,
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
+			},
+		},
+		corev1.EnvVar{
+			Name: constants.EnvVariablePodIP,
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
+			},
+		},
+		corev1.EnvVar{
+			Name: constants.EnvVariablePodServiceAccountName,
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.serviceAccountName"},
+			},
+		},
 	)
 
 	if err := v.checkUniquenessOfVariableNames(varList); err != nil {

--- a/internal/controllers/provider/install/values_test.go
+++ b/internal/controllers/provider/install/values_test.go
@@ -33,8 +33,6 @@ var _ = Describe("Installer", func() {
 			env, err := v.EnvironmentVariables()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(env).To(ContainElement(corev1.EnvVar{Name: envName1, Value: envValue1}))
-			Expect(env).To(ContainElement(corev1.EnvVar{Name: constants.EnvVariableProviderName, Value: providerName}))
-			Expect(env).To(ContainElement(corev1.EnvVar{Name: constants.EnvVariablePlatformClusterNamespace, Value: v.Namespace()}))
 		})
 
 		It("should detect a name conflict", func() {
@@ -43,7 +41,7 @@ var _ = Describe("Installer", func() {
 			provider.SetName(providerName)
 			spec := &v1alpha1.DeploymentSpec{
 				Env: []v1alpha1.EnvVar{
-					{Name: constants.EnvVariableProviderName, Value: envValue1},
+					{Name: constants.EnvVariablePodNamespace, Value: envValue1},
 				},
 			}
 			v := NewValues(provider, spec, "test")


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR changes the arguments and environment variables that are passed to providers:

- Added argument `provider-name`
- Added environment variables `POD_NAME`, `POD_NAMESPACE`, `POD_IP`, `POD_SERVICE_ACCOUNT_NAME`
- Removed environment variable `OPENMCP_PROVIDER_NAME`, which is now available as argument `provider-name`
- Removed environment variable `OPENMCP_PLATFORM_CLUSTER_NAMESPACE`, which is now available as `POD_NAMESPACE`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
- Change of the arguments and environment variables that are passed to providers.
```
