### PR TITLE
feat: install providers in system namespace

### DIFF
--- a/internal/controllers/provider/controller.go
+++ b/internal/controllers/provider/controller.go
@@ -25,18 +25,20 @@ const (
 	openmcpFinalizer = constants.OpenMCPGroupName + "/finalizer"
 )
 
-func NewProviderReconciler(gvk schema.GroupVersionKind, client client.Client, environment string) *ProviderReconciler {
+func NewProviderReconciler(gvk schema.GroupVersionKind, client client.Client, environment, systemNamespace string) *ProviderReconciler {
 	return &ProviderReconciler{
 		GroupVersionKind: gvk,
 		PlatformClient:   client,
 		Environment:      environment,
+		SystemNamespace:  systemNamespace,
 	}
 }
 
 type ProviderReconciler struct {
 	schema.GroupVersionKind
-	PlatformClient client.Client
-	Environment    string
+	PlatformClient  client.Client
+	Environment     string
+	SystemNamespace string
 }
 
 func (r *ProviderReconciler) ControllerName() string {
@@ -119,10 +121,11 @@ func (r *ProviderReconciler) install(
 
 	log := logging.FromContextOrPanic(ctx)
 	installer := install.Installer{
-		PlatformClient: r.PlatformClient,
-		Provider:       provider,
-		DeploymentSpec: deploymentSpec,
-		Environment:    r.Environment,
+		PlatformClient:  r.PlatformClient,
+		Provider:        provider,
+		DeploymentSpec:  deploymentSpec,
+		Environment:     r.Environment,
+		SystemNamespace: r.SystemNamespace,
 	}
 
 	// init job
@@ -171,10 +174,11 @@ func (r *ProviderReconciler) handleDeleteOperation(ctx context.Context, provider
 	status := newUninstallStatus(provider.GetGeneration())
 
 	installer := install.Installer{
-		PlatformClient: r.PlatformClient,
-		Provider:       provider,
-		DeploymentSpec: nil,
-		Environment:    r.Environment,
+		PlatformClient:  r.PlatformClient,
+		Provider:        provider,
+		DeploymentSpec:  nil,
+		Environment:     r.Environment,
+		SystemNamespace: r.SystemNamespace,
 	}
 
 	deleted, err = installer.UninstallProvider(ctx)

--- a/internal/controllers/provider/install/values_test.go
+++ b/internal/controllers/provider/install/values_test.go
@@ -15,9 +15,10 @@ var _ = Describe("Installer", func() {
 	Context("Env Variables", func() {
 
 		const (
-			providerName = "test-provider"
-			envName1     = "NAME_1"
-			envValue1    = "VALUE_1"
+			providerName    = "test-provider"
+			systemNamespace = "openmcp-system"
+			envName1        = "NAME_1"
+			envValue1       = "VALUE_1"
 		)
 
 		It("should contain provider variables and predefined openmcp variables", func() {
@@ -29,7 +30,7 @@ var _ = Describe("Installer", func() {
 					{Name: envName1, Value: envValue1},
 				},
 			}
-			v := NewValues(provider, spec, "test")
+			v := NewValues(provider, spec, "test", systemNamespace)
 			env, err := v.EnvironmentVariables()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(env).To(ContainElement(corev1.EnvVar{Name: envName1, Value: envValue1}))
@@ -44,7 +45,7 @@ var _ = Describe("Installer", func() {
 					{Name: constants.EnvVariablePodNamespace, Value: envValue1},
 				},
 			}
-			v := NewValues(provider, spec, "test")
+			v := NewValues(provider, spec, "test", systemNamespace)
 			_, err := v.EnvironmentVariables()
 			Expect(err).To(HaveOccurred())
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:

For each provider, the openmcp-operator creates/updates certain objects (Job, Deployment, ServiceAccount, Role(Binding), ClusterRole(Binding)). This pull request changes the names and namespaces of these objects. The goal is to have all namespaced resources in a common namespace, namely the system namespace of the openmcp-operator itself &mdash; usually `openmcp-system`. Previously, each provider had its own namespace.

#### Advantages

Pull secrets can be created in one namespace, which is easier for the operator.  
Moreover, providers can share pull secrets.  

#### Naming Scheme

Object names for the cluster provider gardener:

``` 
                          NEW NAMESPACE  / NAME                 OLD NAMESPACE / NAME
Namespaced objects:       openmcp-system / cp-gardener-init     cp-gardener   / gardener-init
                          openmcp-system / cp-gardener          cp-gardener   / gardener

                          NEW NAME                              OLD NAME
Cluster-scoped objects:   openmcp.cloud:cp-gardener-init        cp-gardener:gardener-init
                          openmcp.cloud:cp-gardener             cp-gardener:gardener
```

Prefixes: `cp-` for cluster providers, `sp-` for service providers, `ps-` for platform services.





**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
- Install all providers in a common namespace "openmcp-system"
```
