### PR TITLE
Allow override for 'run' and 'init' command in providers

### DIFF
--- a/api/crds/manifests/openmcp.cloud_clusterproviders.yaml
+++ b/api/crds/manifests/openmcp.cloud_clusterproviders.yaml
@@ -1942,6 +1942,22 @@ spec:
                   - name
                   type: object
                 type: array
+              initCommand:
+                description: |-
+                  InitCommand is the command that is executed to run the init job of the provider.
+                  Defaults to ["init"], if not specified.
+                  The '--environment', '--verbosity', and '--provider-name' flags will be appended to the command automatically.
+                items:
+                  type: string
+                type: array
+              runCommand:
+                description: |-
+                  RunCommand is the command that is executed to run the provider controllers.
+                  Defaults to ["run"], if not specified.
+                  The '--environment', '--verbosity', and '--provider-name' flags will be appended to the command automatically.
+                items:
+                  type: string
+                type: array
               verbosity:
                 default: INFO
                 description: Verbosity is the verbosity level of the provider.

--- a/api/crds/manifests/openmcp.cloud_platformservices.yaml
+++ b/api/crds/manifests/openmcp.cloud_platformservices.yaml
@@ -1942,6 +1942,22 @@ spec:
                   - name
                   type: object
                 type: array
+              initCommand:
+                description: |-
+                  InitCommand is the command that is executed to run the init job of the provider.
+                  Defaults to ["init"], if not specified.
+                  The '--environment', '--verbosity', and '--provider-name' flags will be appended to the command automatically.
+                items:
+                  type: string
+                type: array
+              runCommand:
+                description: |-
+                  RunCommand is the command that is executed to run the provider controllers.
+                  Defaults to ["run"], if not specified.
+                  The '--environment', '--verbosity', and '--provider-name' flags will be appended to the command automatically.
+                items:
+                  type: string
+                type: array
               verbosity:
                 default: INFO
                 description: Verbosity is the verbosity level of the provider.

--- a/api/crds/manifests/openmcp.cloud_serviceproviders.yaml
+++ b/api/crds/manifests/openmcp.cloud_serviceproviders.yaml
@@ -1942,6 +1942,22 @@ spec:
                   - name
                   type: object
                 type: array
+              initCommand:
+                description: |-
+                  InitCommand is the command that is executed to run the init job of the provider.
+                  Defaults to ["init"], if not specified.
+                  The '--environment', '--verbosity', and '--provider-name' flags will be appended to the command automatically.
+                items:
+                  type: string
+                type: array
+              runCommand:
+                description: |-
+                  RunCommand is the command that is executed to run the provider controllers.
+                  Defaults to ["run"], if not specified.
+                  The '--environment', '--verbosity', and '--provider-name' flags will be appended to the command automatically.
+                items:
+                  type: string
+                type: array
               verbosity:
                 default: INFO
                 description: Verbosity is the verbosity level of the provider.

--- a/api/provider/v1alpha1/deployment_types.go
+++ b/api/provider/v1alpha1/deployment_types.go
@@ -21,9 +21,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
-
 // DeploymentSpec defines the desired state of a provider.
 type DeploymentSpec struct {
 	// Image is the name of the image of a provider.
@@ -33,6 +30,18 @@ type DeploymentSpec struct {
 	// ImagePullSecrets are secrets in the same namespace.
 	// They can be used to fetch provider images from private registries.
 	ImagePullSecrets []ObjectReference `json:"imagePullSecrets,omitempty"`
+
+	// InitCommand is the command that is executed to run the init job of the provider.
+	// Defaults to ["init"], if not specified.
+	// The '--environment', '--verbosity', and '--provider-name' flags will be appended to the command automatically.
+	// +optional
+	InitCommand []string `json:"initCommand,omitempty"`
+
+	// RunCommand is the command that is executed to run the provider controllers.
+	// Defaults to ["run"], if not specified.
+	// The '--environment', '--verbosity', and '--provider-name' flags will be appended to the command automatically.
+	// +optional
+	RunCommand []string `json:"runCommand,omitempty"`
 
 	// Env is a list of environment variables to set in the containers of the init job and deployment of the provider.
 	// +optional

--- a/api/provider/v1alpha1/zz_generated.deepcopy.go
+++ b/api/provider/v1alpha1/zz_generated.deepcopy.go
@@ -109,6 +109,16 @@ func (in *DeploymentSpec) DeepCopyInto(out *DeploymentSpec) {
 		*out = make([]ObjectReference, len(*in))
 		copy(*out, *in)
 	}
+	if in.InitCommand != nil {
+		in, out := &in.InitCommand, &out.InitCommand
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.RunCommand != nil {
+		in, out := &in.RunCommand, &out.RunCommand
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env
 		*out = make([]EnvVar, len(*in))

--- a/internal/controllers/provider/testdata/test-04/platformservice.yaml
+++ b/internal/controllers/provider/testdata/test-04/platformservice.yaml
@@ -1,0 +1,18 @@
+apiVersion: openmcp.cloud/v1alpha1
+kind: PlatformService
+metadata:
+  name: platform-service-test-04
+  generation: 1
+spec:
+  image: "test-image:v0.1.0"
+  imagePullSecrets: []
+  initCommand:
+  - test-init
+  - init-subcommand
+  runCommand:
+  - test-run
+  - run-subcommand
+  env:
+    - name: NAME
+      value: "test-name"
+  verbosity: DEBUG


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `initCommand` and `runCommand` fields to the spec of `ServiceProvider`, `ClusterProvider`, and `PlatformService` resources. They allow to override the default run and init commands. For backward compatibility, the field is optional and defaults to the previously expected values if not set.

**Which issue(s) this PR fixes**:
Loosely related to https://github.com/openmcp-project/backlog/issues/210

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The `init` and `run` commands for providers can now be overwritten by using the respective fields in the spec of ServiceProvider`, `ClusterProvider`, and `PlatformService` resources.
```
