### PR TITLE
remove onboarding cluster kubeconfig argument

### DIFF
--- a/cmd/openmcp-operator/app/init.go
+++ b/cmd/openmcp-operator/app/init.go
@@ -65,10 +65,7 @@ func (o *InitOptions) Complete(ctx context.Context) error {
 }
 
 func (o *InitOptions) Run(ctx context.Context) error {
-	if err := o.Clusters.Onboarding.InitializeClient(install.InstallCRDAPIs(runtime.NewScheme())); err != nil {
-		return err
-	}
-	if err := o.Clusters.Platform.InitializeClient(install.InstallCRDAPIs(runtime.NewScheme())); err != nil {
+	if err := o.PlatformCluster.InitializeClient(install.InstallCRDAPIs(runtime.NewScheme())); err != nil {
 		return err
 	}
 
@@ -77,9 +74,7 @@ func (o *InitOptions) Run(ctx context.Context) error {
 
 	// apply CRDs
 	crdManager := crdutil.NewCRDManager(apiconst.ClusterLabel, crds.CRDs)
-
-	crdManager.AddCRDLabelToClusterMapping(clustersv1alpha1.PURPOSE_ONBOARDING, o.Clusters.Onboarding)
-	crdManager.AddCRDLabelToClusterMapping(clustersv1alpha1.PURPOSE_PLATFORM, o.Clusters.Platform)
+	crdManager.AddCRDLabelToClusterMapping(clustersv1alpha1.PURPOSE_PLATFORM, o.PlatformCluster)
 
 	if err := crdManager.CreateOrUpdateCRDs(ctx, &log); err != nil {
 		return fmt.Errorf("error creating/updating CRDs: %w", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
We have a bootstrapping problem (not unsolvable, but annoying) if the openmcp-operator requires a kubeconfig for the onboarding cluster to run. Since the onboarding cluster is not actually needed, let's remove the argument to break the bootstrapping cycle.

**Which issue(s) this PR fixes**:
Loosely related to https://github.com/openmcp-project/backlog/issues/210

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The openmcp-operator now takes a `--kubeconfig` argument for the platform cluster kubeconfig instead of the previous `--platform-cluster` argument. The `--onboarding-cluster` argument has been removed to make the operator work without an existing onboarding cluster.
```
