### PR TITLE
feat: package crds in component

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -14,6 +14,5 @@ includes:
       REPO_URL: 'https://github.com/openmcp-project/openmcp-operator'
       GENERATE_DOCS_INDEX: "true"
       CHART_COMPONENTS: "[]"
-      IMG_COMPONENTS: "[]"
       CRDS_COMPONENTS: "openmcp-operator"
       CRDS_PATH: '{{.ROOT_DIR}}/api/crds/manifests'

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -14,3 +14,6 @@ includes:
       REPO_URL: 'https://github.com/openmcp-project/openmcp-operator'
       GENERATE_DOCS_INDEX: "true"
       CHART_COMPONENTS: "[]"
+      IMG_COMPONENTS: "[]"
+      CRDS_COMPONENTS: "openmcp-operator"
+      CRDS_PATH: '{{.ROOT_DIR}}/api/crds/manifests'


### PR DESCRIPTION
**What this PR does / why we need it**:

Package the custom ressource definition manifests for the openmcp-operator into the OCM component so that they can later be deployed by the bootstrapper.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Package the custom ressource definition manifests for the openmcp-operator into the OCM component 
```
