### PR TITLE
feat(lib): add RoleRef support

### DIFF
--- a/lib/clusteraccess/clusteraccess_test.go
+++ b/lib/clusteraccess/clusteraccess_test.go
@@ -58,11 +58,21 @@ func buildTestEnvironmentReconcile(testdataDir string, objectsWitStatus ...clien
 				},
 			}
 
+			roleRefs := []commonapi.RoleRef{
+				{
+					Kind:      "ClusterRole",
+					Name:      "cluster-admin",
+					Namespace: "",
+				},
+			}
+
 			r := clusteraccess.NewClusterAccessReconciler(c, controllerName)
 			r.WithMCPScheme(scheme).
 				WithWorkloadScheme(scheme).
 				WithMCPPermissions(permissions).
+				WithMCPRoleRefs(roleRefs).
 				WithWorkloadPermissions(permissions).
+				WithWorkloadRoleRefs(roleRefs).
 				WithRetryInterval(1 * time.Second)
 			return r
 		}).


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for adding RoleRefs to the MCP and Workload cluster.

**Which issue(s) this PR fixes**:
Related https://github.com/openmcp-project/service-provider-crossplane/issues/21

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Adding support in the lib to reference RoleRefs in the ClusterAccess reconciler.
```
