### PR TITLE
fix: remove namespace from ClusterProfile's provider and providerconfig references

### DIFF
--- a/api/clusters/v1alpha1/clusterprofile_types.go
+++ b/api/clusters/v1alpha1/clusterprofile_types.go
@@ -9,10 +9,10 @@ import (
 // ClusterProfileSpec defines the desired state of Provider.
 type ClusterProfileSpec struct {
 	// ProviderRef is a reference to the ClusterProvider
-	ProviderRef commonapi.ObjectReference `json:"providerRef"`
+	ProviderRef commonapi.LocalObjectReference `json:"providerRef"`
 
 	// ProviderConfigRef is a reference to the provider-specific configuration.
-	ProviderConfigRef commonapi.ObjectReference `json:"providerConfigRef"`
+	ProviderConfigRef commonapi.LocalObjectReference `json:"providerConfigRef"`
 
 	// SupportedVersions are the supported Kubernetes versions.
 	SupportedVersions []SupportedK8sVersion `json:"supportedVersions"`

--- a/api/crds/manifests/clusters.openmcp.cloud_clusterprofiles.yaml
+++ b/api/crds/manifests/clusters.openmcp.cloud_clusterprofiles.yaml
@@ -55,28 +55,30 @@ spec:
                   configuration.
                 properties:
                   name:
-                    description: Name is the name of the object.
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                     type: string
-                  namespace:
-                    description: Namespace is the namespace of the object.
-                    type: string
-                required:
-                - name
-                - namespace
                 type: object
+                x-kubernetes-map-type: atomic
               providerRef:
                 description: ProviderRef is a reference to the ClusterProvider
                 properties:
                   name:
-                    description: Name is the name of the object.
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                     type: string
-                  namespace:
-                    description: Namespace is the namespace of the object.
-                    type: string
-                required:
-                - name
-                - namespace
                 type: object
+                x-kubernetes-map-type: atomic
               supportedVersions:
                 description: SupportedVersions are the supported Kubernetes versions.
                 items:


### PR DESCRIPTION
**What this PR does / why we need it**:
When we changed the reference types, the references in the ClusterProfile resource were accidentally changed from non-namespaced references to namespaced ones. This PR fixes that.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The `providerRef` and `providerConfigRef` fields in the `ClusterProfile`'s spec now only take a name and no namespace, as intended.
```
