### PR TITLE
feat: MCP purpose override

### DIFF
--- a/api/constants/constants.go
+++ b/api/constants/constants.go
@@ -16,6 +16,8 @@ const (
 
 	// ManagedByLabel is used to indicate which controller manages the resource.
 	ManagedByLabel = OpenMCPGroupName + "/managed-by"
+	// ManagedPurposeLabel is used to indicate the purpose of the resource.
+	ManagedPurposeLabel = OpenMCPGroupName + "/managed-purpose"
 
 	// OnboardingNameLabel is used to store the name on the onboarding cluster of a resource.
 	OnboardingNameLabel = OpenMCPGroupName + "/onboarding-name"

--- a/api/core/v2alpha1/constants.go
+++ b/api/core/v2alpha1/constants.go
@@ -8,9 +8,13 @@ const (
 )
 
 const (
-	MCPNameLabel      = GroupName + "/mcp-name"
-	MCPNamespaceLabel = GroupName + "/mcp-namespace"
-	OIDCProviderLabel = GroupName + "/oidc-provider"
+	MCPNameLabel            = GroupName + "/mcp-name"
+	MCPNamespaceLabel       = GroupName + "/mcp-namespace"
+	OIDCProviderLabel       = GroupName + "/oidc-provider"
+	MCPPurposeOverrideLabel = GroupName + "/purpose-override"
+
+	// ManagedPurposeMCPPurposeOverride is used as value for the managed purpose label. It must not be modified.
+	ManagedPurposeMCPPurposeOverride = "mcp-purpose-override"
 
 	MCPFinalizer = GroupName + "/mcp"
 

--- a/api/core/v2alpha1/constants.go
+++ b/api/core/v2alpha1/constants.go
@@ -11,7 +11,7 @@ const (
 	MCPNameLabel            = GroupName + "/mcp-name"
 	MCPNamespaceLabel       = GroupName + "/mcp-namespace"
 	OIDCProviderLabel       = GroupName + "/oidc-provider"
-	MCPPurposeOverrideLabel = GroupName + "/purpose-override"
+	MCPPurposeOverrideLabel = GroupName + "/purpose"
 
 	// ManagedPurposeMCPPurposeOverride is used as value for the managed purpose label. It must not be modified.
 	ManagedPurposeMCPPurposeOverride = "mcp-purpose-override"

--- a/cmd/openmcp-operator/app/mcp/init.go
+++ b/cmd/openmcp-operator/app/mcp/init.go
@@ -190,7 +190,7 @@ func (o *InitOptions) Run(ctx context.Context) error {
 				Message:    fmt.Sprintf(`The label "%s" is immutable, it cannot be added after creation and is not allowed to be changed or removed once set.`, corev2alpha1.MCPPurposeOverrideLabel),
 			},
 			{
-				Expression: `variables.purposeOverrideLabel.contains("mcp")`,
+				Expression: `(variables.purposeOverrideLabel == "") || variables.purposeOverrideLabel.contains("mcp")`,
 				Message:    fmt.Sprintf(`The value of the label "%s" must contain "mcp".`, corev2alpha1.MCPPurposeOverrideLabel),
 			},
 		},

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 
 - [AccessRequest Controller](controller/accessrequest.md)
 - [Deployment Controllers](controller/deployment.md)
+- [ManagedControlPlane v2](controller/managedcontrolplane.md)
 - [Cluster Scheduler](controller/scheduler.md)
 
 ## Resources

--- a/docs/controller/managedcontrolplane.md
+++ b/docs/controller/managedcontrolplane.md
@@ -1,0 +1,82 @@
+# ManagedControlPlane v2
+
+The *ManagedControlPlane v2 Controller* is a platform service that is responsible for reconciling `ManagedControlPlaneV2` (MCP) resources.
+
+Out of an MCP resource, it generates a `ClusterRequest` and multiple `AccessReqests`, thereby handling cluster management and authentication/authorization for MCPs.
+
+## Configuration
+
+The MCP controller takes the following configuration:
+```yaml
+managedControlPlane:
+  mcpClusterPurpose: mcp # defaults to 'mcp'
+  reconcileMCPEveryXDays: 7 # defaults to 0
+  defaultOIDCProvider:
+    name: my-oidc-provider
+    issuer: https://oidc.example.com
+    clientID: my-client-id
+    usernamePrefix: "my-user:"
+    groupsPrefix: "my-group:"
+    extraScopes:
+    - foo
+```
+
+The configuration is optional.
+
+## ManagedControlPlaneV2
+
+This is an example MCP resource:
+```yaml
+apiVersion: core.openmcp.cloud/v2alpha1
+kind: ManagedControlPlaneV2
+metadata:
+  name: mcp-01
+  namespace: foo
+spec:
+  iam:
+    roleBindings: # this sets the role bindings for the default OIDC provider (no effect if none is configured)
+    - subjects:
+      - kind: User
+        name: john.doe@example.com
+      roleRefs:
+      - kind: ClusterRole
+        name: cluster-admin
+    oidcProviders: # here, additional OIDC providers can be configured
+    - name: my-oidc-provider
+      issuer: https://oidc.example.com
+      clientID: my-client-id
+      usernamePrefix: "my-user:"
+      groupsPrefix: "my-group:"
+      extraScopes:
+      - foo
+      roleBindings:
+      - subjects:
+        - kind: User
+          name: foo
+        - kind: Group
+          name: bar
+        roleRefs:
+        - kind: ClusterRole
+          name: my-cluster-role
+        - kind: Role
+          name: my-role
+          namespace: default
+```
+
+### Purpose Overriding
+
+Usually, an MCP resource results in a `ClusterRequest` with its `spec.purpose` set to whatever is configured in the MCP controller configuration (defaults to `mcp` if not specified). The `core.openmcp.cloud/purpose` label allows to override this setting and specify a different purpose for a single MCP.
+
+Note that the purpose cannot be changed anymore after creation of the `ClusterRequest`, therefore the label has to be present already during creation of the MCP resource, it cannot be added afterwards.
+
+Also, it is not verified whether the chosen purpose actually is known to the scheduler. Specifying a unknown purpose will result in the MCP resource never becoming ready.
+
+#### Validation
+
+During setup, the MCP controller deploys a `ValidatingAdmissionPolicy` for the aforementioned label. It has the following effects:
+- The label cannot be added or removed to/from an existing MCP resource.
+- The label's value cannot be changed.
+- The label's value must contain the substring `mcp`.
+  - This is meant to prevent customers (who have access to this label) from hijacking cluster purposes that are not meant for MCP clusters.
+
+This validation is currently not configurable in any way.

--- a/docs/controller/managedcontrolplane.md
+++ b/docs/controller/managedcontrolplane.md
@@ -12,7 +12,7 @@ managedControlPlane:
   mcpClusterPurpose: mcp # defaults to 'mcp'
   reconcileMCPEveryXDays: 7 # defaults to 0
   defaultOIDCProvider:
-    name: my-oidc-provider
+    name: default # must be 'default' or omitted for the default oidc provider
     issuer: https://oidc.example.com
     clientID: my-client-id
     usernamePrefix: "my-user:"

--- a/internal/controllers/managedcontrolplane/testdata/test-01/onboarding/mcp-02.yaml
+++ b/internal/controllers/managedcontrolplane/testdata/test-01/onboarding/mcp-02.yaml
@@ -1,0 +1,8 @@
+apiVersion: core.openmcp.cloud/v2alpha1
+kind: ManagedControlPlaneV2
+metadata:
+  name: mcp-02
+  namespace: test
+  labels:
+    core.openmcp.cloud/purpose: my-mcp-purpose
+spec: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a label that can be used on the MCPv2 resource to override the default purpose.
A ValidatingAdmissionPolicy prevents updating or removing the label after creation.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The label `core.openmcp.cloud/purpose` can now be used on `ManagedControlPlaneV2` resources to override the default cluster purpose.
```
