### PR TITLE
refactor: change default scheduler scope to 'Cluster'

### DIFF
--- a/docs/controller/scheduler.md
+++ b/docs/controller/scheduler.md
@@ -9,7 +9,7 @@ To disable the scheduler, make sure that `scheduler` is not part of the `--contr
 If not disabled, the scheduler requires a config that looks like this:
 ```yaml
 scheduler:
-  scope: Namespaced  # optional
+  scope: Cluster  # optional
   strategy: Balanced # optional
 
   selectors:                  # optional
@@ -58,7 +58,7 @@ scheduler:
 ```
 
 The following fields can be specified inside the `scheduler` field:
-- `scope` _(optional, defaults to `Namespaced`)_
+- `scope` _(optional, defaults to `Cluster`)_
   - Valid values: `Namespaced`, `Cluster`
   - Determines whether the scheduler takes `Cluster` resources in all namespaces into accounts or only in a specific one.
     - In `Namespaced` mode, only `Cluster` resources from a single namespace are taken into account when checking for existing clusters to schedule requests to. If the cluster template that corresponds to the purpose specified in the request has a `metadata.namespace` set, this namespace is used to check for `Cluster` resources and also to create new ones. If not, the namespace of the `ClusterRequest` resource is used instead.

--- a/internal/config/config_scheduler.go
+++ b/internal/config/config_scheduler.go
@@ -73,7 +73,7 @@ type SchedulerSelectors struct {
 
 func (c *SchedulerConfig) Default(_ *field.Path) error {
 	if c.Scope == "" {
-		c.Scope = SCOPE_NAMESPACED
+		c.Scope = SCOPE_CLUSTER
 	}
 	if c.Strategy == "" {
 		c.Strategy = STRATEGY_BALANCED

--- a/internal/controllers/scheduler/controller_test.go
+++ b/internal/controllers/scheduler/controller_test.go
@@ -51,6 +51,7 @@ var _ = Describe("Scheduler", func() {
 		It("should create a new exclusive cluster if no cluster exists", func() {
 			clusterNamespace := "exclusive"
 			sc, env := defaultTestSetup("testdata", "test-01")
+			Expect(sc.Config.Scope).To(Equal(config.SCOPE_NAMESPACED))
 			Expect(env.Client().DeleteAllOf(env.Ctx, &clustersv1alpha1.Cluster{}, client.InNamespace(clusterNamespace))).To(Succeed())
 			existingClusters := &clustersv1alpha1.ClusterList{}
 			Expect(env.Client().List(env.Ctx, existingClusters, client.InNamespace(clusterNamespace))).To(Succeed())
@@ -78,6 +79,7 @@ var _ = Describe("Scheduler", func() {
 		It("should create a new exclusive cluster if a cluster exists", func() {
 			clusterNamespace := "exclusive"
 			sc, env := defaultTestSetup("testdata", "test-01")
+			Expect(sc.Config.Scope).To(Equal(config.SCOPE_NAMESPACED))
 			existingClusters := &clustersv1alpha1.ClusterList{}
 			Expect(env.Client().List(env.Ctx, existingClusters, client.InNamespace(clusterNamespace))).To(Succeed())
 			oldCount := len(existingClusters.Items)
@@ -107,6 +109,7 @@ var _ = Describe("Scheduler", func() {
 		It("should create a new shared cluster if no cluster exists", func() {
 			clusterNamespace := "shared-twice"
 			sc, env := defaultTestSetup("testdata", "test-01")
+			Expect(sc.Config.Scope).To(Equal(config.SCOPE_NAMESPACED))
 			Expect(env.Client().DeleteAllOf(env.Ctx, &clustersv1alpha1.Cluster{}, client.InNamespace(clusterNamespace))).To(Succeed())
 			existingClusters := &clustersv1alpha1.ClusterList{}
 			Expect(env.Client().List(env.Ctx, existingClusters, client.InNamespace(clusterNamespace))).To(Succeed())
@@ -134,6 +137,7 @@ var _ = Describe("Scheduler", func() {
 		It("should share a shared cluster if it still has capacity and create a new one otherwise", func() {
 			clusterNamespace := "shared-twice"
 			sc, env := defaultTestSetup("testdata", "test-01")
+			Expect(sc.Config.Scope).To(Equal(config.SCOPE_NAMESPACED))
 			existingClusters := &clustersv1alpha1.ClusterList{}
 			Expect(env.Client().List(env.Ctx, existingClusters, client.InNamespace(clusterNamespace))).To(Succeed())
 			oldCount := len(existingClusters.Items)
@@ -214,6 +218,7 @@ var _ = Describe("Scheduler", func() {
 		It("should only create a new cluster if none exists for unlimitedly shared clusters", func() {
 			clusterNamespace := "shared-unlimited"
 			sc, env := defaultTestSetup("testdata", "test-01")
+			Expect(sc.Config.Scope).To(Equal(config.SCOPE_NAMESPACED))
 			reqCount := 20
 			requests := make([]*clustersv1alpha1.ClusterRequest, reqCount)
 			for i := range reqCount {
@@ -244,7 +249,8 @@ var _ = Describe("Scheduler", func() {
 		})
 
 		It("should take over annotations and labels from the cluster template", func() {
-			_, env := defaultTestSetup("testdata", "test-02")
+			sc, env := defaultTestSetup("testdata", "test-02")
+			Expect(sc.Config.Scope).To(Equal(config.SCOPE_NAMESPACED))
 
 			req := &clustersv1alpha1.ClusterRequest{}
 			Expect(env.Client().Get(env.Ctx, ctrlutils.ObjectKey("exclusive", "foo"), req)).To(Succeed())
@@ -262,7 +268,8 @@ var _ = Describe("Scheduler", func() {
 
 		It("should use the request's namespace if none is specified in the template and ignore clusters that don't match the label selector", func() {
 			clusterNamespace := "foo"
-			_, env := defaultTestSetup("testdata", "test-02")
+			sc, env := defaultTestSetup("testdata", "test-02")
+			Expect(sc.Config.Scope).To(Equal(config.SCOPE_NAMESPACED))
 
 			req := &clustersv1alpha1.ClusterRequest{}
 			Expect(env.Client().Get(env.Ctx, ctrlutils.ObjectKey("shared", "foo"), req)).To(Succeed())
@@ -316,7 +323,8 @@ var _ = Describe("Scheduler", func() {
 	Context("Scope: Cluster", func() {
 
 		It("should evaluate all namespaces in cluster scope", func() {
-			_, env := defaultTestSetup("testdata", "test-03")
+			sc, env := defaultTestSetup("testdata", "test-03")
+			Expect(sc.Config.Scope).To(Equal(config.SCOPE_CLUSTER))
 
 			req := &clustersv1alpha1.ClusterRequest{}
 			Expect(env.Client().Get(env.Ctx, ctrlutils.ObjectKey("shared", "foo"), req)).To(Succeed())

--- a/internal/controllers/scheduler/testdata/test-01/config.yaml
+++ b/internal/controllers/scheduler/testdata/test-01/config.yaml
@@ -1,4 +1,5 @@
 scheduler:
+  scope: Namespaced
   purposeMappings:
     exclusive:
       template:

--- a/internal/controllers/scheduler/testdata/test-02/config.yaml
+++ b/internal/controllers/scheduler/testdata/test-02/config.yaml
@@ -1,4 +1,5 @@
 scheduler:
+  scope: Namespaced
   selectors:
     clusters:
       matchLabels:

--- a/internal/controllers/scheduler/testdata/test-03/config.yaml
+++ b/internal/controllers/scheduler/testdata/test-03/config.yaml
@@ -1,5 +1,4 @@
 scheduler:
-  scope: Cluster
   selectors:
     clusters:
       matchLabels:


### PR DESCRIPTION
**What this PR does / why we need it**:
As our current landscape setup relies on the scheduler working in cluster-scope mode, I changed the default scope (which applies if not explicitly set in the config) to `Cluster` to reduce the risk of accidental misconfiguration.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The scheduler's default scope has been changed to `Cluster` (was `Namespaced` before).
```
