### PR TITLE
refactor: make logging verbosity case-insensitive

### DIFF
--- a/api/crds/manifests/openmcp.cloud_clusterproviders.yaml
+++ b/api/crds/manifests/openmcp.cloud_clusterproviders.yaml
@@ -2071,6 +2071,9 @@ spec:
                 - DEBUG
                 - INFO
                 - ERROR
+                - debug
+                - info
+                - error
                 type: string
             required:
             - image

--- a/api/crds/manifests/openmcp.cloud_platformservices.yaml
+++ b/api/crds/manifests/openmcp.cloud_platformservices.yaml
@@ -2071,6 +2071,9 @@ spec:
                 - DEBUG
                 - INFO
                 - ERROR
+                - debug
+                - info
+                - error
                 type: string
             required:
             - image

--- a/api/crds/manifests/openmcp.cloud_serviceproviders.yaml
+++ b/api/crds/manifests/openmcp.cloud_serviceproviders.yaml
@@ -2071,6 +2071,9 @@ spec:
                 - DEBUG
                 - INFO
                 - ERROR
+                - debug
+                - info
+                - error
                 type: string
             required:
             - image

--- a/api/provider/v1alpha1/deployment_types.go
+++ b/api/provider/v1alpha1/deployment_types.go
@@ -54,7 +54,7 @@ type DeploymentSpec struct {
 	Env []EnvVar `json:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// Verbosity is the verbosity level of the provider.
-	// +kubebuilder:validation:Enum=DEBUG;INFO;ERROR
+	// +kubebuilder:validation:Enum=DEBUG;INFO;ERROR;debug;info;error
 	// +kubebuilder:default=INFO
 	Verbosity string `json:"verbosity,omitempty"`
 


### PR DESCRIPTION
**What this PR does / why we need it**:
There was a hard validation for the logging verbosity in the provider resources to be one of `DEBUG`, `INFO`, or `ERROR`. As the logger is actually case-insensitive regarding this argument, I added the lowercase variants of the three verbosities to the validation enum.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
It is now possible to specify the logging verbosity in the `PlatformService`, `ClusterProvider`, and `ServiceProvider` resources also in lowercase.
```
