### PR TITLE
refactor: OIDC validation and defaulting

### DIFF
--- a/api/core/v2alpha1/constants.go
+++ b/api/core/v2alpha1/constants.go
@@ -15,6 +15,8 @@ const (
 
 	// ManagedPurposeMCPPurposeOverride is used as value for the managed purpose label. It must not be modified.
 	ManagedPurposeMCPPurposeOverride = "mcp-purpose-override"
+	// ManagedPurposeOIDCProviderNameUniqueness is used as value for the managed purpose label. It must not be modified.
+	ManagedPurposeOIDCProviderNameUniqueness = "oidc-provider-name-uniqueness"
 
 	MCPFinalizer = GroupName + "/mcp"
 

--- a/api/core/v2alpha1/constants.go
+++ b/api/core/v2alpha1/constants.go
@@ -2,7 +2,7 @@ package v2alpha1
 
 const (
 	// DefaultOIDCProviderName is the identifier for the default OIDC provider.
-	DefaultOIDCProviderName = "default"
+	DefaultOIDCProviderName = "openmcp"
 	// DefaultMCPClusterPurpose is the default purpose for ManagedControlPlane clusters.
 	DefaultMCPClusterPurpose = "mcp"
 )

--- a/api/core/v2alpha1/managedcontrolplane_types.go
+++ b/api/core/v2alpha1/managedcontrolplane_types.go
@@ -31,7 +31,6 @@ type IAMConfig struct {
 
 	// OIDCProviders is a list of OIDC providers that should be configured for the ManagedControlPlaneV2.
 	// They are independent of the standard OIDC provider and in addition to it, unless it has been disabled by not specifying any role bindings.
-	// +kubebuilder:validation:items:XValidation:rule="self.name != 'default'", message="OIDC provider name must not be 'default' as this is reserved for the standard OIDC provider"
 	// +optional
 	OIDCProviders []*commonapi.OIDCProviderConfig `json:"oidcProviders,omitempty"`
 }

--- a/api/crds/manifests/clusters.openmcp.cloud_accessrequests.yaml
+++ b/api/crds/manifests/clusters.openmcp.cloud_accessrequests.yaml
@@ -73,6 +73,7 @@ spec:
                 properties:
                   clientID:
                     description: ClientID is the client ID to use for the OIDC provider.
+                    minLength: 1
                     type: string
                   extraScopes:
                     description: ExtraScopes is a list of extra scopes that should
@@ -86,24 +87,28 @@ spec:
                       GroupsClaim is the claim in the OIDC token that contains the groups.
                       If empty, the default claim "groups" will be used.
                     type: string
-                  groupsPrefix:
-                    description: |-
-                      GroupsPrefix is a prefix that will be added to all group names when referenced in RBAC rules.
-                      This is required to avoid conflicts with Kubernetes built-in groups.
-                      If the prefix does not end with a colon (:), it will be added automatically.
-                    minLength: 1
-                    type: string
                   issuer:
-                    description: Issuer is the issuer URL of the OIDC provider.
+                    description: |-
+                      Issuer is the issuer URL of the OIDC provider.
+                      Must be a valid URL.
+                    minLength: 1
+                    pattern: ^https?://[^\s/$.?#].[^\s]*$
                     type: string
                   name:
                     description: |-
                       Name is the name of the OIDC provider.
                       May be used in k8s resources, therefore has to be a valid k8s name.
+                      It is also used (with a ':' suffix) as prefix in k8s resources referencing users or groups from this OIDC provider.
+                      E.g. if the name is 'example', the username 'alice' from this provider will be referenced as 'example:alice' in k8s resources.
+                      Must be unique among all OIDC providers configured in the same environment.
                     maxLength: 253
                     minLength: 1
-                    pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
+                    x-kubernetes-validations:
+                    - message: '''system'' is a reserved string and may not be used
+                        as OIDC provider name'
+                      rule: self != "system"
                   roleBindings:
                     description: |-
                       RoleBindings is a list of subjects with (cluster) role bindings that should be created for them.
@@ -260,20 +265,11 @@ spec:
                       UsernameClaim is the claim in the OIDC token that contains the username.
                       If empty, the default claim "sub" will be used.
                     type: string
-                  usernamePrefix:
-                    description: |-
-                      UsernamePrefix is a prefix that will be added to all usernames when referenced in RBAC rules.
-                      This is required to avoid conflicts with Kubernetes built-in users.
-                      If the prefix does not end with a colon (:), it will be added automatically.
-                    minLength: 1
-                    type: string
                 required:
                 - clientID
-                - groupsPrefix
                 - issuer
                 - name
                 - roleBindings
-                - usernamePrefix
                 type: object
               requestRef:
                 description: |-

--- a/api/crds/manifests/core.openmcp.cloud_managedcontrolplanev2s.yaml
+++ b/api/crds/manifests/core.openmcp.cloud_managedcontrolplanev2s.yaml
@@ -182,10 +182,6 @@ spec:
                       - name
                       - roleBindings
                       type: object
-                      x-kubernetes-validations:
-                      - message: OIDC provider name must not be 'default' as this
-                          is reserved for the standard OIDC provider
-                        rule: self.name != 'default'
                     type: array
                   roleBindings:
                     description: |-

--- a/api/crds/manifests/core.openmcp.cloud_managedcontrolplanev2s.yaml
+++ b/api/crds/manifests/core.openmcp.cloud_managedcontrolplanev2s.yaml
@@ -58,6 +58,7 @@ spec:
                         clientID:
                           description: ClientID is the client ID to use for the OIDC
                             provider.
+                          minLength: 1
                           type: string
                         extraScopes:
                           description: ExtraScopes is a list of extra scopes that
@@ -71,24 +72,28 @@ spec:
                             GroupsClaim is the claim in the OIDC token that contains the groups.
                             If empty, the default claim "groups" will be used.
                           type: string
-                        groupsPrefix:
-                          description: |-
-                            GroupsPrefix is a prefix that will be added to all group names when referenced in RBAC rules.
-                            This is required to avoid conflicts with Kubernetes built-in groups.
-                            If the prefix does not end with a colon (:), it will be added automatically.
-                          minLength: 1
-                          type: string
                         issuer:
-                          description: Issuer is the issuer URL of the OIDC provider.
+                          description: |-
+                            Issuer is the issuer URL of the OIDC provider.
+                            Must be a valid URL.
+                          minLength: 1
+                          pattern: ^https?://[^\s/$.?#].[^\s]*$
                           type: string
                         name:
                           description: |-
                             Name is the name of the OIDC provider.
                             May be used in k8s resources, therefore has to be a valid k8s name.
+                            It is also used (with a ':' suffix) as prefix in k8s resources referencing users or groups from this OIDC provider.
+                            E.g. if the name is 'example', the username 'alice' from this provider will be referenced as 'example:alice' in k8s resources.
+                            Must be unique among all OIDC providers configured in the same environment.
                           maxLength: 253
                           minLength: 1
-                          pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                           type: string
+                          x-kubernetes-validations:
+                          - message: '''system'' is a reserved string and may not
+                              be used as OIDC provider name'
+                            rule: self != "system"
                         roleBindings:
                           description: |-
                             RoleBindings is a list of subjects with (cluster) role bindings that should be created for them.
@@ -171,20 +176,11 @@ spec:
                             UsernameClaim is the claim in the OIDC token that contains the username.
                             If empty, the default claim "sub" will be used.
                           type: string
-                        usernamePrefix:
-                          description: |-
-                            UsernamePrefix is a prefix that will be added to all usernames when referenced in RBAC rules.
-                            This is required to avoid conflicts with Kubernetes built-in users.
-                            If the prefix does not end with a colon (:), it will be added automatically.
-                          minLength: 1
-                          type: string
                       required:
                       - clientID
-                      - groupsPrefix
                       - issuer
                       - name
                       - roleBindings
-                      - usernamePrefix
                       type: object
                       x-kubernetes-validations:
                       - message: OIDC provider name must not be 'default' as this

--- a/docs/controller/managedcontrolplane.md
+++ b/docs/controller/managedcontrolplane.md
@@ -12,11 +12,9 @@ managedControlPlane:
   mcpClusterPurpose: mcp # defaults to 'mcp'
   reconcileMCPEveryXDays: 7 # defaults to 0
   defaultOIDCProvider:
-    name: default # must be 'default' or omitted for the default oidc provider
+    name: openmcp # defaults to 'openmcp' when omitted
     issuer: https://oidc.example.com
     clientID: my-client-id
-    usernamePrefix: "my-user:"
-    groupsPrefix: "my-group:"
     extraScopes:
     - foo
 ```
@@ -45,8 +43,6 @@ spec:
     - name: my-oidc-provider
       issuer: https://oidc.example.com
       clientID: my-client-id
-      usernamePrefix: "my-user:"
-      groupsPrefix: "my-group:"
       extraScopes:
       - foo
       roleBindings:

--- a/internal/config/config_managedcontrolplane.go
+++ b/internal/config/config_managedcontrolplane.go
@@ -1,8 +1,6 @@
 package config
 
 import (
-	"fmt"
-
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	commonapi "github.com/openmcp-project/openmcp-operator/api/common"
@@ -54,8 +52,8 @@ func (c *ManagedControlPlaneConfig) Validate(fldPath *field.Path) error {
 		if len(c.DefaultOIDCProvider.RoleBindings) > 0 {
 			errs = append(errs, field.Forbidden(oidcFldPath.Child("roleBindings"), "role bindings are specified in the MCP spec and may not be set in the config"))
 		}
-		if c.DefaultOIDCProvider.Name != "" && c.DefaultOIDCProvider.Name != corev2alpha1.DefaultOIDCProviderName {
-			errs = append(errs, field.Invalid(oidcFldPath.Child("name"), c.DefaultOIDCProvider.Name, fmt.Sprintf("standard OIDC provider name must be '%s' or left empty (in which case it will be defaulted)", corev2alpha1.DefaultOIDCProviderName)))
+		if c.DefaultOIDCProvider.Name == "system" {
+			errs = append(errs, field.Invalid(oidcFldPath.Child("name"), c.DefaultOIDCProvider.Name, "'system' is a reserved string and may not be used as name for the default OIDC provider"))
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Improves validation and defaulting of the `OIDCProviderConfig` struct (used in AccessRequests and MCPv2 resources, as well as MCPv2 controller config):
- `usernamePrefix` and `groupsPrefix` have been removed and are now always assumed to be `<name>:`.
- `name` is not allowed to be set to `system`. This prevents impersonating k8s service accounts.
- The regex validation rule for `name` has been fixed.
- `issuer` and `clientID` are now required and the former one must look like an URL.
- Upon initialization, the MCPv2 controller now creates a `ValidatingAdmissionPolicy` which ensures that MCPv2s don't specify duplicate OIDC provider names and no OIDC provider that conflicts with the default one.
- The naming restriction for the default OIDC provider has been removed (was restricted to `default` before) and it is now defaulted to `openmcp` instead.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
The validation for the `spec.iam.oidcProviders` field in the `ManagedControlPlaneV2` resource has been changed in multiple ways:
- `usernamePrefix` and `groupsPrefix` have been removed and are now always assumed to be `<name>:`
- `name` is not allowed to be set to `system` (prevents k8s service account impersonation)
- The regex validation rule for `name` has been fixed
- `issuer` and `clientID` are now required and the former one must look like an URL
- Duplicate OIDC provider names or ones that clash with the default OIDC provider are now prevented
```
```breaking operator
The naming restriction for the default OIDC provider has been removed (was restricted to `default` before) and it is now defaulted to `openmcp` instead.
```
