### PR TITLE
feat: allow to skip the workload cluster management

### DIFF
--- a/lib/clusteraccess/clusteraccess.go
+++ b/lib/clusteraccess/clusteraccess.go
@@ -93,7 +93,7 @@ type reconcilerImpl struct {
 	workloadRoleRefs      []commonapi.RoleRef
 	mcpScheme             *runtime.Scheme
 	workloadScheme        *runtime.Scheme
-	SkipWorkloadCLuster   bool
+	skipWorkloadCluster   bool
 }
 
 // NewClusterAccessReconciler creates a new ClusterAccessReconciler with the given parameters.
@@ -110,7 +110,7 @@ func NewClusterAccessReconciler(platformClusterClient client.Client, controllerN
 		workloadRoleRefs:      []commonapi.RoleRef{},
 		mcpScheme:             runtime.NewScheme(),
 		workloadScheme:        runtime.NewScheme(),
-		SkipWorkloadCLuster:   false,
+		skipWorkloadCluster:   false,
 	}
 }
 
@@ -150,7 +150,7 @@ func (r *reconcilerImpl) WithWorkloadScheme(scheme *runtime.Scheme) Reconciler {
 }
 
 func (r *reconcilerImpl) SkipWorkloadCluster() Reconciler {
-	r.SkipWorkloadCLuster = true
+	r.skipWorkloadCluster = true
 	return r
 }
 
@@ -255,7 +255,7 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, request reconcile.Reques
 		return reconcile.Result{RequeueAfter: r.retryInterval}, nil
 	}
 
-	if !r.SkipWorkloadCLuster {
+	if !r.skipWorkloadCluster {
 		// Create or update the ClusterRequest for the Workload cluster and wait until it is ready.
 
 		log.Debug("Create and wait for Workload cluster request", "clusterRequestName", requestNameWorkload, "clusterRequestNamespace", requestNamespace)
@@ -315,7 +315,7 @@ func (r *reconcilerImpl) ReconcileDelete(ctx context.Context, request reconcile.
 	workloadAccessDeleted := true
 	workloadClusterDeleted := true
 
-	if !r.SkipWorkloadCLuster {
+	if !r.skipWorkloadCluster {
 		// Delete the Workload AccessRequest if it exists
 		workloadAccessDeleted, err = deleteAccessRequest(ctx, r.platformClusterClient, requestNameWorkload, requestNamespace)
 		if err != nil {

--- a/lib/clusteraccess/clusteraccess_test.go
+++ b/lib/clusteraccess/clusteraccess_test.go
@@ -129,12 +129,14 @@ func buildTestEnvironmentNoReconcile(testdataDir string, objectsWitStatus ...cli
 		Build()
 }
 
+const (
+	expectedRequestNamespace = "mcp--80158a25-6874-80a6-a75d-94f57da600c0"
+)
+
 var _ = Describe("ClusterAccessReconciler", func() {
 	Context("Reconcile", func() {
 		It("should create MCP-/Workload ClusterRequests/AccessRequests", func() {
 			var reconcileResult reconcile.Result
-
-			expectedRequestNamespace := "mcp--80158a25-6874-80a6-a75d-94f57da600c0"
 
 			request := reconcile.Request{
 				NamespacedName: client.ObjectKey{
@@ -254,8 +256,6 @@ var _ = Describe("ClusterAccessReconciler", func() {
 		It("should create MCP-/Workload ClusterRequests/AccessRequests without Workload Cluster", func() {
 			var reconcileResult reconcile.Result
 
-			expectedRequestNamespace := "mcp--80158a25-6874-80a6-a75d-94f57da600c0"
-
 			request := reconcile.Request{
 				NamespacedName: client.ObjectKey{
 					Name:      "instance",
@@ -326,10 +326,10 @@ var _ = Describe("ClusterAccessReconciler", func() {
 
 			accessRequestList := &clustersv1alpha1.AccessRequestList{}
 			Expect(env.Client().List(env.Ctx, accessRequestList, client.InNamespace(expectedRequestNamespace))).To(Succeed())
-			Expect(len(accessRequestList.Items)).To(Equal(1), "there should be only one access request (for the MCP cluster)")
+			Expect(accessRequestList.Items).To(HaveLen(1), "there should be only one access request (for the MCP cluster)")
 			clusterRequestList := &clustersv1alpha1.ClusterRequestList{}
 			Expect(env.Client().List(env.Ctx, clusterRequestList, client.InNamespace(expectedRequestNamespace))).To(Succeed())
-			Expect(len(clusterRequestList.Items)).To(Equal(0), "there should be no cluster request (for the Workload cluster)")
+			Expect(clusterRequestList.Items).To(BeEmpty(), "there should be no cluster request (for the Workload cluster)")
 		})
 
 		Context("Delete", func() {
@@ -377,7 +377,7 @@ var _ = Describe("ClusterAccessReconciler", func() {
 				Expect(env.Client().Get(env.Ctx, client.ObjectKeyFromObject(accessRequestWorkload), accessRequestWorkload)).ToNot(Succeed(), "access request for Workload cluster should not exist")
 			})
 
-			It("should delete only MCP AccessRequest with SkipWorkloadCluster", func() {
+			It("should delete only MCP AccessRequest with skipWorkloadCluster", func() {
 				var reconcileResult reconcile.Result
 
 				expectedRequestNamespace := "mcp--80158a25-6874-80a6-a75d-94f57da600c0"


### PR DESCRIPTION
**What this PR does / why we need it**:

The Access Request Reconciler was always creating an access for the MCP cluster and the Workload cluster.
Since some of the service providers are not using a workload cluster, add an option to skip the management of a Workload cluster.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Allow to skip management of Workload cluster in Access Request Reconciler
```
