### PR TITLE
fix: requeue mcp if not ready

### DIFF
--- a/internal/controllers/managedcontrolplane/testdata/test-02/config.yaml
+++ b/internal/controllers/managedcontrolplane/testdata/test-02/config.yaml
@@ -1,0 +1,7 @@
+managedControlPlane:
+  mcpClusterPurpose: mcp
+  reconcileMCPEveryXDays: 7
+  defaultOIDCProvider:
+    issuer: https://example.com/oidc
+    groupsPrefix: 'mygroups:'
+    usernamePrefix: 'myuser:'

--- a/internal/controllers/managedcontrolplane/testdata/test-02/onboarding/mcp-01.yaml
+++ b/internal/controllers/managedcontrolplane/testdata/test-02/onboarding/mcp-01.yaml
@@ -1,0 +1,19 @@
+apiVersion: core.openmcp.cloud/v2alpha1
+kind: ManagedControlPlaneV2
+metadata:
+  name: mcp-01
+  namespace: test
+  uid: 6aa4f8e1-a590-4fd7-b751-0b93f9f38bde
+spec:
+  iam:
+    tokens:
+      - name: viewer
+        permissions:
+          - rules:
+              - apiGroups: [ '' ]
+                resources: [ 'pods', 'services' ]
+                verbs: [ 'get', 'list', 'watch' ]
+status:
+  access:
+    token_viewer:
+      name: 6nilzexg

--- a/internal/controllers/managedcontrolplane/testdata/test-02/onboarding/mcp-access-secret-01.yaml
+++ b/internal/controllers/managedcontrolplane/testdata/test-02/onboarding/mcp-access-secret-01.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+data:
+  kubeconfig: ZmFrZQ==
+kind: Secret
+metadata:
+  labels:
+    core.openmcp.cloud/mcp-name: mcp-01
+    core.openmcp.cloud/mcp-namespace: test
+    core.openmcp.cloud/token-provider: viewer
+    openmcp.cloud/managed-by: ManagedControlPlane
+  name: 6nilzexg
+  namespace: test
+  ownerReferences:
+  - apiVersion: core.openmcp.cloud/v2alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: ManagedControlPlaneV2
+    name: mcp-01
+    uid: 6aa4f8e1-a590-4fd7-b751-0b93f9f38bde
+type: Opaque

--- a/internal/controllers/managedcontrolplane/testdata/test-02/platform/ar-01.yaml
+++ b/internal/controllers/managedcontrolplane/testdata/test-02/platform/ar-01.yaml
@@ -1,0 +1,40 @@
+apiVersion: clusters.openmcp.cloud/v1alpha1
+kind: AccessRequest
+metadata:
+  finalizers:
+  - clusters.openmcp.cloud/finalizer
+  labels:
+    clusters.openmcp.cloud/profile: kind
+    clusters.openmcp.cloud/provider: kind
+    core.openmcp.cloud/mcp-name: mcp-01
+    core.openmcp.cloud/mcp-namespace: test
+    core.openmcp.cloud/token-provider: viewer
+    openmcp.cloud/managed-by: ManagedControlPlane
+  name: c73jfgp2
+  namespace: mcp--ac6294ed-3227-8926-b364-f791fabdb843
+  uid: 5ebc81b8-8d5a-4e57-9d7e-7ea4b915fcaf
+spec:
+  clusterRef:
+    name: mcp-12345
+    namespace: mcp--ac6294ed-3227-8926-b364-f791fabdb843
+  requestRef:
+    name: mcp-01
+    namespace: mcp--ac6294ed-3227-8926-b364-f791fabdb843
+  token:
+    permissions:
+    - rules:
+      - apiGroups:
+        - ""
+        resources:
+        - pods
+        - services
+        verbs:
+        - get
+        - list
+        - watch
+status:
+  observedGeneration: 2
+  phase: Granted
+  secretRef:
+    name: c73jfgp2.kubeconfig
+    namespace: mcp--ac6294ed-3227-8926-b364-f791fabdb843

--- a/internal/controllers/managedcontrolplane/testdata/test-02/platform/ar-secret-01.yaml
+++ b/internal/controllers/managedcontrolplane/testdata/test-02/platform/ar-secret-01.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  creationTimestamp: "2025-10-14T11:02:07Z"
+  name: c73jfgp2.kubeconfig
+  namespace: mcp--ac6294ed-3227-8926-b364-f791fabdb843
+  ownerReferences:
+  - apiVersion: clusters.openmcp.cloud/v1alpha1
+    kind: AccessRequest
+    name: c73jfgp2
+    uid: 5ebc81b8-8d5a-4e57-9d7e-7ea4b915fcaf
+  resourceVersion: "629926"
+  uid: b7c4bf8e-442f-4c54-8eff-b7b5e4a41a4d
+type: Opaque
+data:
+  kubeconfig: ZmFrZQ==

--- a/internal/controllers/managedcontrolplane/testdata/test-02/platform/cluster-01.yaml
+++ b/internal/controllers/managedcontrolplane/testdata/test-02/platform/cluster-01.yaml
@@ -1,0 +1,36 @@
+apiVersion: clusters.openmcp.cloud/v1alpha1
+kind: Cluster
+metadata:
+  finalizers:
+  - request.clusters.openmcp.cloud/24143a57-be40-495e-96e2-4623e563a066
+  - clusters.openmcp.cloud/finalizer
+  generation: 1
+  labels:
+    clusters.openmcp.cloud/delete-without-requests: "true"
+  name: mcp-12345
+  namespace: mcp--ac6294ed-3227-8926-b364-f791fabdb843
+spec:
+  kubernetes: {}
+  profile: kind
+  purposes:
+  - mcp
+  tenancy: Exclusive
+status:
+  conditions:
+  - lastTransitionTime: "2025-09-22T08:23:32Z"
+    message: ""
+    reason: ClusterExists
+    status: "True"
+    type: KindReady
+  - lastTransitionTime: "2025-09-22T08:24:02Z"
+    message: ""
+    reason: AllPodsReady
+    status: "True"
+    type: MetalLBReady
+  - lastTransitionTime: "2025-09-22T08:24:02Z"
+    message: ""
+    reason: ClusterAndMetalLBReady
+    status: "False"
+    type: Ready
+  observedGeneration: 0
+  phase: Progressing

--- a/internal/controllers/managedcontrolplane/testdata/test-02/platform/cr-01.yaml
+++ b/internal/controllers/managedcontrolplane/testdata/test-02/platform/cr-01.yaml
@@ -1,0 +1,19 @@
+apiVersion: clusters.openmcp.cloud/v1alpha1
+kind: ClusterRequest
+metadata:
+  labels:
+    core.openmcp.cloud/mcp-name: mcp-01
+    core.openmcp.cloud/mcp-namespace: test
+    openmcp.cloud/managed-by: ManagedControlPlane
+  name: mcp-01
+  namespace: mcp--ac6294ed-3227-8926-b364-f791fabdb843
+  uid: 24143a57-be40-495e-96e2-4623e563a066
+spec:
+  purpose: mcp
+  waitForClusterDeletion: true
+status:
+  cluster:
+    name: mcp-12345
+    namespace: mcp--ac6294ed-3227-8926-b364-f791fabdb843
+  observedGeneration: 1
+  phase: Granted


### PR DESCRIPTION
**What this PR does / why we need it**:
Before this, whether an MCPv2 was requeued or not solely depended on the readiness of all access variants configured in the MCP. Since the MCP syncs the conditions from its `Cluster` and only becomes `Ready` if all conditions are healthy, it could happen that all `AccessRequests` and related secrets became ready while the `Cluster` still had unhealthy conditions. This would then lead to the MCP being stuck in `Progressing` until a reconciliation was triggered somehow.

With this PR, the MCP will be requeued for reconciliation if its phase is not `Ready`, even when all configured accesses are already available. This prevents the aforementioned problem.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed a bug that caused an `MCPv2` to not be requeued for reconciliation despite not being `Ready` yet, causing it to be stuck in `Progressing` until a reconciliation was triggered externally.
```
