### PR TITLE
feat: exclude provider fields from status update & utility to set these fields 

### DIFF
--- a/internal/controllers/provider/controller_test.go
+++ b/internal/controllers/provider/controller_test.go
@@ -189,4 +189,32 @@ var _ = Describe("Deployment Controller", func() {
 			Expect(provider2.Object).To(Equal(provider.Object))
 		})
 	})
+
+	Context("Copy field between unstructured", func() {
+
+		sliceCopy := []any{"c", "o", "p", "y"}
+		sliceKeep := []any{"k", "e", "e", "p"}
+		fieldPathCopy := []string{"status", "resourcesCopy"}
+		fieldPathKeep := []string{"status", "resourcesKeep"}
+
+		It("should copy a nested slice and keep another field", func() {
+			u1 := &unstructured.Unstructured{Object: map[string]any{}}
+			Expect(unstructured.SetNestedSlice(u1.Object, sliceCopy, fieldPathCopy...)).To(Succeed())
+
+			u2 := &unstructured.Unstructured{Object: map[string]any{}}
+			Expect(unstructured.SetNestedSlice(u2.Object, sliceKeep, fieldPathKeep...)).To(Succeed())
+
+			Expect(CopyNestedSlice(u1, u2, fieldPathCopy...)).To(Succeed())
+
+			value, found, err := unstructured.NestedSlice(u2.Object, fieldPathCopy...)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
+			Expect(value).To(Equal(sliceCopy))
+
+			value, found, err = unstructured.NestedSlice(u2.Object, fieldPathKeep...)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
+			Expect(value).To(Equal(sliceKeep))
+		})
+	})
 })

--- a/lib/utils/provider.go
+++ b/lib/utils/provider.go
@@ -1,0 +1,41 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openmcp-project/openmcp-operator/api/provider/v1alpha1"
+)
+
+// GetServiceProviderResource retrieves the ServiceProvider resource with the given name using the provided platform client.
+func GetServiceProviderResource(ctx context.Context, platformClient client.Client, providerName string) (*v1alpha1.ServiceProvider, error) {
+	serviceProvider := &v1alpha1.ServiceProvider{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: providerName,
+		},
+	}
+	if err := platformClient.Get(ctx, client.ObjectKeyFromObject(serviceProvider), serviceProvider); err != nil {
+		return nil, fmt.Errorf("failed to get service provider resource %s: %w", providerName, err)
+	}
+	return serviceProvider, nil
+}
+
+// RegisterGVKsAtServiceProvider updates the status.resources field of the ServiceProvider resource with the provided GroupVersionKinds.
+// This can be used by service providers, for example in their init job, to register the kinds of resources they manage.
+func RegisterGVKsAtServiceProvider(ctx context.Context, platformClient client.Client, providerName string, gvks ...metav1.GroupVersionKind) error {
+	providerResource, err := GetServiceProviderResource(ctx, platformClient, providerName)
+	if err != nil {
+		return err
+	}
+
+	providerResourceOld := providerResource.DeepCopy()
+	providerResource.Status.Resources = gvks
+	if err := platformClient.Status().Patch(ctx, providerResource, client.MergeFrom(providerResourceOld)); err != nil {
+		return fmt.Errorf("failed to patch platform service provider status: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

ServiceProvider resources have a status field `status.resources` where a service provider can register the GroupVersionKinds of the resources it manages. This PR provides a utility function to update the ServiceProvider status with such GVKs. It could be used for example by service providers in their init job.

This PR also ensures that the openmcp operator keeps the `status.resources` field when it reconciles a ServiceProvider resource.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
- Utility function for service providers to add the kinds of their managed resources to the ServiceProvider status 
```
