### PR TITLE
feat: allow to control the high availability config of ps mcp

### DIFF
--- a/cmd/openmcp-operator/app/init.go
+++ b/cmd/openmcp-operator/app/init.go
@@ -218,6 +218,8 @@ func (o *InitOptions) Run(ctx context.Context) error {
 				ps.Spec.RunCommand = append(ps.Spec.RunCommand, "--config="+cp)
 			}
 			ps.Spec.Verbosity = verbosity
+			ps.Spec.RunReplicas = *o.Config.ManagedControlPlane.PlatformService.Replicas
+			ps.Spec.TopologySpreadConstraints = o.Config.ManagedControlPlane.PlatformService.TopologySpreadConstraints
 			return nil
 		}); err != nil {
 			return fmt.Errorf("error creating/updating PlatformService %s: %w", ps.Name, err)

--- a/cmd/openmcp-operator/app/mcp/run.go
+++ b/cmd/openmcp-operator/app/mcp/run.go
@@ -269,11 +269,6 @@ func (o *RunOptions) Run(ctx context.Context) error {
 		TLSOpts: o.WebhookTLSOpts,
 	})
 
-	podNamespace := os.Getenv(apiconst.EnvVariablePodNamespace)
-	if podNamespace == "" {
-		return fmt.Errorf("environment variable %s is not set", apiconst.EnvVariablePodNamespace)
-	}
-
 	mgr, err := ctrl.NewManager(onboardingCluster.RESTConfig(), ctrl.Options{
 		Scheme:                  onboardingCluster.Scheme(),
 		Metrics:                 o.MetricsServerOptions,
@@ -282,7 +277,7 @@ func (o *RunOptions) Run(ctx context.Context) error {
 		PprofBindAddress:        o.PprofAddr,
 		LeaderElection:          o.EnableLeaderElection,
 		LeaderElectionID:        "github.com/openmcp-project/openmcp-operator--mcp-controller",
-		LeaderElectionNamespace: podNamespace,
+		LeaderElectionNamespace: providerSystemNamespace,
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly

--- a/internal/config/config_managedcontrolplane.go
+++ b/internal/config/config_managedcontrolplane.go
@@ -1,7 +1,9 @@
 package config
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
 
 	commonapi "github.com/openmcp-project/openmcp-operator/api/common"
 	corev2alpha1 "github.com/openmcp-project/openmcp-operator/api/core/v2alpha1"
@@ -23,6 +25,21 @@ type ManagedControlPlaneConfig struct {
 	// A value of 0 disables the periodic reconciliation.
 	// +optional
 	ReconcileMCPEveryXDays int `json:"reconcileMCPEveryXDays,omitempty"`
+
+	// PlatformService specifies the configuration for the ManagedControlPlane platform service.
+	PlatformService ManagedControlPlaneConfigPlatformService `json:"platformService,omitempty"`
+}
+type ManagedControlPlaneConfigPlatformService struct {
+	// Replicas specifies the default number of replicas for ManagedControlPlane platform service.
+	// Default is 1.
+	// +optional
+	Replicas *int32 `json:"replicas,omitempty"`
+
+	// TopologySpreadConstraints specifies the default topology spread constraints for ManagedControlPlane platform service.
+	// More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+	// The label selector for the topology spread constraints is set to match the labels of the ManagedControlPlane platform service.
+	// +optional
+	TopologySpreadConstraints []corev1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
 }
 
 func (c *ManagedControlPlaneConfig) Default(_ *field.Path) error {
@@ -34,6 +51,9 @@ func (c *ManagedControlPlaneConfig) Default(_ *field.Path) error {
 	}
 	if c.MCPClusterPurpose == "" {
 		c.MCPClusterPurpose = corev2alpha1.DefaultMCPClusterPurpose
+	}
+	if c.PlatformService.Replicas == nil {
+		c.PlatformService.Replicas = ptr.To[int32](1)
 	}
 	return nil
 }
@@ -55,6 +75,9 @@ func (c *ManagedControlPlaneConfig) Validate(fldPath *field.Path) error {
 		if c.DefaultOIDCProvider.Name == "system" {
 			errs = append(errs, field.Invalid(oidcFldPath.Child("name"), c.DefaultOIDCProvider.Name, "'system' is a reserved string and may not be used as name for the default OIDC provider"))
 		}
+	}
+	if c.PlatformService.Replicas != nil && *c.PlatformService.Replicas < 1 {
+		errs = append(errs, field.Invalid(fldPath.Child("replicas"), c.PlatformService.Replicas, "replicas must be at least 1"))
 	}
 
 	return errs.ToAggregate()


### PR DESCRIPTION
**What this PR does / why we need it**:

Allow to configure number of replicas and topology spread constraints of the platform service managed control plane.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Allow to configure number of replicas and topology spread constraints of the platform service managed control plane.

```
