### PR TITLE
feat(managedcontrolplane): user-friendly secret name for MCP access

### DIFF
--- a/internal/controllers/managedcontrolplane/controller_test.go
+++ b/internal/controllers/managedcontrolplane/controller_test.go
@@ -327,6 +327,8 @@ var _ = Describe("ManagedControlPlane Controller", func() {
 			sec.SetNamespace(mcp.Namespace)
 			Expect(env.Client(onboarding).Get(env.Ctx, client.ObjectKeyFromObject(sec), sec)).To(Succeed())
 			Expect(sec.Data).To(HaveKeyWithValue(clustersv1alpha1.SecretKeyKubeconfig, []byte(providerName)))
+			providerPrefix := strings.ReplaceAll(providerName, "_", "-")
+			Expect(sec.Name).To(Equal(strings.Join([]string{providerPrefix, mcp.Name, "kubeconfig"}, ".")))
 		}
 
 		By("=== UPDATE ===")


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces a new name pattern for MCP access secrets on the onboarding cluster. The secret name clearly refers to the corresponding MCP IAM spec values as follows: `<provider-name>.<mcp-name>.kubeconfig` where provider-name is either an OIDC provider or static token name.

**Which issue(s) this PR fixes**:
Fixes #162 

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
New name pattern for MCP access secrets on the onboarding cluster. The secret name clearly refers to the corresponding MCP IAM spec values as follows: `<provider-name>.<mcp-name>.kubeconfig` where provider-name is either an OIDC provider or static token name.
```
