### PR TITLE
fix: too long label values from clusteraccess library

### DIFF
--- a/lib/clusteraccess/advanced/clusteraccess.go
+++ b/lib/clusteraccess/advanced/clusteraccess.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/openmcp-project/controller-utils/pkg/clusters"
 	maputils "github.com/openmcp-project/controller-utils/pkg/collections/maps"
+	ctrlutils "github.com/openmcp-project/controller-utils/pkg/controller"
 	"github.com/openmcp-project/controller-utils/pkg/logging"
 
 	clustersv1alpha1 "github.com/openmcp-project/openmcp-operator/api/clusters/v1alpha1"
@@ -51,6 +52,7 @@ type ClusterAccessReconciler interface {
 	// Note that the implementation might depend on these labels to identify the resources it created,
 	// so changing them might lead to unexpected behavior. They also must be unique within the context of this reconciler.
 	// Use with caution.
+	// Note that all label values are put through a function which replaces a part of them with a unique and deterministic hash if they exceed the maximum allowed length for Kubernetes label values.
 	WithManagedLabels(gen ManagedLabelGenerator) ClusterAccessReconciler
 
 	// Access returns an internal Cluster object granting access to the cluster for the specified request with the specified id.
@@ -133,6 +135,18 @@ type FakingCallback func(ctx context.Context, platformClusterClient client.Clien
 // The third return value can be nil, or it can contain additional labels to be set on the created resources.
 type ManagedLabelGenerator func(controllerName string, req reconcile.Request, reg ClusterRegistration) (string, string, map[string]string)
 
+func ensureManagedLabelLength(gen ManagedLabelGenerator) ManagedLabelGenerator {
+	return func(controllerName string, req reconcile.Request, reg ClusterRegistration) (string, string, map[string]string) {
+		mb, mp, add := gen(controllerName, req, reg)
+		mb = ctrlutils.ShortenToXCharactersUnsafe(mb, ctrlutils.K8sMaxNameLength)
+		mp = ctrlutils.ShortenToXCharactersUnsafe(mp, ctrlutils.K8sMaxNameLength)
+		for k, v := range add {
+			add[k] = ctrlutils.ShortenToXCharactersUnsafe(v, ctrlutils.K8sMaxNameLength)
+		}
+		return mb, mp, add
+	}
+}
+
 func DefaultManagedLabelGenerator(controllerName string, req reconcile.Request, reg ClusterRegistration) (string, string, map[string]string) {
 	sb := strings.Builder{}
 	if req.Namespace != "" {
@@ -178,7 +192,7 @@ func NewClusterAccessReconciler(platformClusterClient client.Client, controllerN
 		ridLock:               &sync.RWMutex{},
 		interval:              5 * time.Second,
 		registrations:         map[string]ClusterRegistration{},
-		managedBy:             DefaultManagedLabelGenerator,
+		managedBy:             ensureManagedLabelLength(DefaultManagedLabelGenerator),
 	}
 }
 
@@ -677,7 +691,7 @@ func (r *reconcilerImpl) WithManagedLabels(gen ManagedLabelGenerator) ClusterAcc
 	if gen == nil {
 		gen = DefaultManagedLabelGenerator
 	}
-	r.managedBy = gen
+	r.managedBy = ensureManagedLabelLength(gen)
 	return r
 }
 

--- a/lib/clusteraccess/advanced/clusteraccess_test.go
+++ b/lib/clusteraccess/advanced/clusteraccess_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -573,6 +574,58 @@ var _ = Describe("Advanced Cluster Access", func() {
 		Expect(ar.Labels).To(HaveKeyWithValue(openmcpconst.ManagedByLabel, "my-managed-by"))
 		Expect(ar.Labels).To(HaveKeyWithValue(openmcpconst.ManagedPurposeLabel, "my-purpose"))
 		Expect(ar.Labels).To(HaveKeyWithValue("custom-label", "custom-value"))
+	})
+
+	It("should prevent label values from being too long (default managed label generator)", func() {
+		env := defaultTestSetup("testdata", "test-01")
+		rec := defaultClusterAccessReconciler(env, "foo")
+		rec.Register(advanced.ExistingClusterRequest("foobar", "fb", advanced.StaticReferenceGenerator(&commonapi.ObjectReference{
+			Name:      "cr-01",
+			Namespace: "test",
+		})).WithTokenAccess(&clustersv1alpha1.TokenConfig{}).Build())
+		req := testutils.RequestFromStrings("this-is-an-absolutely-very-long-namespace-name", "this-is-an-absolutely-very-long-name")
+
+		Eventually(expectNoRequeue(env.Ctx, rec, req, false)).Should(Succeed())
+
+		// check AccessRequest
+		ar, err := rec.AccessRequest(env.Ctx, req, "foobar")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ar.Name).To(Equal(advanced.StableRequestName("foo", req, "fb")))
+		namespace, err := advanced.DefaultNamespaceGenerator(req)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ar.Namespace).To(Equal(namespace))
+		Expect(ar.Labels).To(HaveKey(openmcpconst.ManagedByLabel))
+		Expect(len(ar.Labels[openmcpconst.ManagedByLabel])).To(BeNumerically("<=", 63))
+		Expect(ar.Labels).To(HaveKey(openmcpconst.ManagedPurposeLabel))
+		Expect(len(ar.Labels[openmcpconst.ManagedPurposeLabel])).To(BeNumerically("<=", 63))
+	})
+
+	It("should prevent label values from being too long (custom managed label generator)", func() {
+		env := defaultTestSetup("testdata", "test-01")
+		rec := defaultClusterAccessReconciler(env, "foo").WithManagedLabels(func(controllerName string, req reconcile.Request, reg advanced.ClusterRegistration) (string, string, map[string]string) {
+			return strings.Repeat("my-managed-by", 6), strings.Repeat("my-purpose", 8), map[string]string{"custom-label": strings.Repeat("custom-value", 7)}
+		})
+		rec.Register(advanced.ExistingClusterRequest("foobar", "fb", advanced.StaticReferenceGenerator(&commonapi.ObjectReference{
+			Name:      "cr-01",
+			Namespace: "test",
+		})).WithTokenAccess(&clustersv1alpha1.TokenConfig{}).Build())
+		req := testutils.RequestFromStrings("bar", "baz")
+
+		Eventually(expectNoRequeue(env.Ctx, rec, req, false)).Should(Succeed())
+
+		// check AccessRequest
+		ar, err := rec.AccessRequest(env.Ctx, req, "foobar")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ar.Name).To(Equal(advanced.StableRequestName("foo", req, "fb")))
+		namespace, err := advanced.DefaultNamespaceGenerator(req)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ar.Namespace).To(Equal(namespace))
+		Expect(ar.Labels).To(HaveKey(openmcpconst.ManagedByLabel))
+		Expect(len(ar.Labels[openmcpconst.ManagedByLabel])).To(BeNumerically("<=", 63))
+		Expect(ar.Labels).To(HaveKey(openmcpconst.ManagedPurposeLabel))
+		Expect(len(ar.Labels[openmcpconst.ManagedPurposeLabel])).To(BeNumerically("<=", 63))
+		Expect(ar.Labels).To(HaveKey("custom-label"))
+		Expect(len(ar.Labels["custom-label"])).To(BeNumerically("<=", 63))
 	})
 
 	It("should requeue if the ClusterRequest or AccessRequest is not yet ready", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
The clusteraccess library generates label values based on resource names, which can, for long resource names, exceed the limit of 63 characters. This PR fixes the problem.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
The clusteraccess library now automatically shortens the values of the managed labels to 63 characters, if they exceed this limit (the shortened values contain a hash of the original value and are therefore still unique). This also applies if a custom generator for the managed labels is used.
```
