### PR TITLE
feat: make HelmRelease more customizable

### DIFF
--- a/api/crds/manifests/helm.open-control-plane.io_helmdeployments.yaml
+++ b/api/crds/manifests/helm.open-control-plane.io_helmdeployments.yaml
@@ -597,9 +597,59 @@ spec:
                 - message: exactly one of the fields in [helm git oci] must be set
                   rule: '[has(self.helm),has(self.git),has(self.oci)].filter(x,x==true).size()
                     == 1'
+              commonMetadata:
+                description: |-
+                  CommonMetadata allows to specify common metadata for the HelmRelease, e.g. labels and annotations.
+                  Inherited from HelmRelease spec.
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations to be added to the object's metadata.
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels to be added to the object's metadata.
+                    type: object
+                type: object
+              healthCheckExprs:
+                description: |-
+                  HealthCheckExprs allows to specify custom health checks for the HelmRelease.
+                  Inherited from HelmRelease spec.
+                items:
+                  description: CustomHealthCheck defines the health check for custom
+                    resources.
+                  properties:
+                    apiVersion:
+                      description: APIVersion of the custom resource under evaluation.
+                      type: string
+                    current:
+                      description: |-
+                        Current is the CEL expression that determines if the status
+                        of the custom resource has reached the desired state.
+                      type: string
+                    failed:
+                      description: |-
+                        Failed is the CEL expression that determines if the status
+                        of the custom resource has failed to reach the desired state.
+                      type: string
+                    inProgress:
+                      description: |-
+                        InProgress is the CEL expression that determines if the status
+                        of the custom resource has not yet reached the desired state.
+                      type: string
+                    kind:
+                      description: Kind of the custom resource under evaluation.
+                      type: string
+                  required:
+                  - apiVersion
+                  - current
+                  type: object
+                type: array
               helmValues:
                 description: |-
-                  HelmValues are the helm values to deploy external-dns with, if the purpose selector matches.
+                  HelmValues are the helm values to deploy the chart with.
                   There are a few special strings which will be replaced before creating the HelmRelease:
                   - <provider.name> will be replaced with the provider name resource.
                   - <provider.namespace> will be replaced with the namespace that hosts the platform service.
@@ -610,12 +660,225 @@ spec:
                   - <cluster.namespace> will be replaced with the namespace of the reconciled Cluster.
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
+              install:
+                description: |-
+                  Install allows to overwrite the default install options for the HelmRelease.
+                  Inherited from HelmRelease spec.
+                properties:
+                  crds:
+                    description: |-
+                      CRDs upgrade CRDs from the Helm Chart's crds directory according
+                      to the CRD upgrade policy provided here. Valid values are `Skip`,
+                      `Create` or `CreateReplace`. Default is `Create` and if omitted
+                      CRDs are installed but not updated.
+
+                      Skip: do neither install nor replace (update) any CRDs.
+
+                      Create: new CRDs are created, existing CRDs are neither updated nor deleted.
+
+                      CreateReplace: new CRDs are created, existing CRDs are updated (replaced)
+                      but not deleted.
+
+                      By default, CRDs are applied (installed) during Helm install action.
+                      With this option users can opt in to CRD replace existing CRDs on Helm
+                      install actions, which is not (yet) natively supported by Helm.
+                      https://helm.sh/docs/chart_best_practices/custom_resource_definitions.
+                    enum:
+                    - Skip
+                    - Create
+                    - CreateReplace
+                    type: string
+                  createNamespace:
+                    description: |-
+                      CreateNamespace tells the Helm install action to create the
+                      HelmReleaseSpec.TargetNamespace if it does not exist yet.
+                      On uninstall, the namespace will not be garbage collected.
+                    type: boolean
+                  disableHooks:
+                    description: DisableHooks prevents hooks from running during the
+                      Helm install action.
+                    type: boolean
+                  disableOpenAPIValidation:
+                    description: |-
+                      DisableOpenAPIValidation prevents the Helm install action from validating
+                      rendered templates against the Kubernetes OpenAPI Schema.
+                    type: boolean
+                  disableSchemaValidation:
+                    description: |-
+                      DisableSchemaValidation prevents the Helm install action from validating
+                      the values against the JSON Schema.
+                    type: boolean
+                  disableTakeOwnership:
+                    description: |-
+                      DisableTakeOwnership disables taking ownership of existing resources
+                      during the Helm install action. Defaults to false.
+                    type: boolean
+                  disableWait:
+                    description: |-
+                      DisableWait disables the waiting for resources to be ready after a Helm
+                      install has been performed.
+                    type: boolean
+                  disableWaitForJobs:
+                    description: |-
+                      DisableWaitForJobs disables waiting for jobs to complete after a Helm
+                      install has been performed.
+                    type: boolean
+                  remediation:
+                    description: |-
+                      Remediation holds the remediation configuration for when the Helm install
+                      action for the HelmRelease fails. The default is to not perform any action.
+                    properties:
+                      ignoreTestFailures:
+                        description: |-
+                          IgnoreTestFailures tells the controller to skip remediation when the Helm
+                          tests are run after an install action but fail. Defaults to
+                          'Test.IgnoreFailures'.
+                        type: boolean
+                      remediateLastFailure:
+                        description: |-
+                          RemediateLastFailure tells the controller to remediate the last failure, when
+                          no retries remain. Defaults to 'false'.
+                        type: boolean
+                      retries:
+                        description: |-
+                          Retries is the number of retries that should be attempted on failures before
+                          bailing. Remediation, using an uninstall, is performed between each attempt.
+                          Defaults to '0', a negative integer equals to unlimited retries.
+                        type: integer
+                    type: object
+                  replace:
+                    description: |-
+                      Replace tells the Helm install action to re-use the 'ReleaseName', but only
+                      if that name is a deleted release which remains in the history.
+                    type: boolean
+                  serverSideApply:
+                    description: |-
+                      ServerSideApply enables server-side apply for resources during install.
+                      Defaults to true (or false when UseHelm3Defaults feature gate is enabled).
+                    type: boolean
+                  skipCRDs:
+                    description: |-
+                      SkipCRDs tells the Helm install action to not install any CRDs. By default,
+                      CRDs are installed if not already present.
+
+                      Deprecated use CRD policy (`crds`) attribute with value `Skip` instead.
+                    type: boolean
+                  strategy:
+                    description: |-
+                      Strategy defines the install strategy to use for this HelmRelease.
+                      Defaults to 'RemediateOnFailure', or 'RetryOnFailure' when the
+                      DefaultToRetryOnFailure feature gate is enabled.
+                    properties:
+                      name:
+                        description: Name of the install strategy.
+                        enum:
+                        - RemediateOnFailure
+                        - RetryOnFailure
+                        type: string
+                      retryInterval:
+                        description: |-
+                          RetryInterval is the interval at which to retry a failed install.
+                          Can be used only when Name is set to RetryOnFailure.
+                          Defaults to '5m'.
+                        pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                        type: string
+                    required:
+                    - name
+                    type: object
+                    x-kubernetes-validations:
+                    - message: .retryInterval cannot be set when .name is 'RemediateOnFailure'
+                      rule: '!has(self.retryInterval) || self.name != ''RemediateOnFailure'''
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation (like
+                      Jobs for hooks) during the performance of a Helm install action. Defaults to
+                      'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              interval:
+                description: |-
+                  Interval at which to reconcile the Helm release.
+                  It can be used to overwrite the default reconciliation interval specified in the provider config.
+                  Inherited from HelmRelease spec.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
               namespace:
                 description: |-
                   Namespace is the namespace on the target cluster to use for the helm deployment.
                   If secrets are copied onto the target cluster, they will be copied into this namespace.
                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                 type: string
+              releaseName:
+                description: |-
+                  ReleaseName used for the Helm release.
+                  Defaults to <namespace>--<name>--<hash> (shortened to 63 characters) if not set.
+                  Inherited from HelmRelease spec.
+                maxLength: 53
+                minLength: 1
+                type: string
+              rollback:
+                description: |-
+                  Rollback allows to overwrite the default rollback options for the HelmRelease.
+                  Inherited from HelmRelease spec.
+                properties:
+                  cleanupOnFail:
+                    description: |-
+                      CleanupOnFail allows deletion of new resources created during the Helm
+                      rollback action when it fails.
+                    type: boolean
+                  disableHooks:
+                    description: DisableHooks prevents hooks from running during the
+                      Helm rollback action.
+                    type: boolean
+                  disableWait:
+                    description: |-
+                      DisableWait disables the waiting for resources to be ready after a Helm
+                      rollback has been performed.
+                    type: boolean
+                  disableWaitForJobs:
+                    description: |-
+                      DisableWaitForJobs disables waiting for jobs to complete after a Helm
+                      rollback has been performed.
+                    type: boolean
+                  force:
+                    description: |-
+                      Force forces resource updates through a replacement strategy
+                      that avoids 3-way merge conflicts on client-side apply.
+                      This field is ignored for server-side apply (which always
+                      forces conflicts with other field managers).
+                    type: boolean
+                  recreate:
+                    description: |-
+                      Recreate performs pod restarts for any managed workloads.
+
+                      Deprecated: This behavior was deprecated in Helm 3:
+                        - Deprecation: https://github.com/helm/helm/pull/6463
+                        - Removal: https://github.com/helm/helm/pull/31023
+                      After helm-controller was upgraded to the Helm 4 SDK,
+                      this field is no longer functional and will print a
+                      warning if set to true. It will also be removed in a
+                      future release.
+                    type: boolean
+                  serverSideApply:
+                    description: |-
+                      ServerSideApply enables server-side apply for resources during rollback.
+                      Can be "enabled", "disabled", or "auto".
+                      When "auto", server-side apply usage will be based on the release's previous usage.
+                      Defaults to "auto".
+                    enum:
+                    - enabled
+                    - disabled
+                    - auto
+                    type: string
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation (like
+                      Jobs for hooks) during the performance of a Helm rollback action. Defaults to
+                      'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
               secretsToCopy:
                 description: |-
                   SecretsToCopy defines which secrets should be copied for this HelmDeployment.
@@ -823,6 +1086,261 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              test:
+                description: |-
+                  Test allows to overwrite the default test options for the HelmRelease.
+                  Inherited from HelmRelease spec.
+                properties:
+                  enable:
+                    description: |-
+                      Enable enables Helm test actions for this HelmRelease after an Helm install
+                      or upgrade action has been performed.
+                    type: boolean
+                  filters:
+                    description: Filters is a list of tests to run or exclude from
+                      running.
+                    items:
+                      description: Filter holds the configuration for individual Helm
+                        test filters.
+                      properties:
+                        exclude:
+                          description: Exclude specifies whether the named test should
+                            be excluded.
+                          type: boolean
+                        name:
+                          description: Name is the name of the test.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  ignoreFailures:
+                    description: |-
+                      IgnoreFailures tells the controller to skip remediation when the Helm tests
+                      are run but fail. Can be overwritten for tests run after install or upgrade
+                      actions in 'Install.IgnoreTestFailures' and 'Upgrade.IgnoreTestFailures'.
+                    type: boolean
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation during
+                      the performance of a Helm test action. Defaults to 'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              timeout:
+                description: |-
+                  Timeout to set for the HelmRelease.
+                  Flux defaults this to 5 minutes, if not overwritten here.
+                  Inherited from HelmRelease spec.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+              uninstall:
+                description: |-
+                  Uninstall allows to overwrite the default uninstall options for the HelmRelease.
+                  Inherited from HelmRelease spec.
+                properties:
+                  deletionPropagation:
+                    default: background
+                    description: |-
+                      DeletionPropagation specifies the deletion propagation policy when
+                      a Helm uninstall is performed.
+                    enum:
+                    - background
+                    - foreground
+                    - orphan
+                    type: string
+                  disableHooks:
+                    description: DisableHooks prevents hooks from running during the
+                      Helm rollback action.
+                    type: boolean
+                  disableWait:
+                    description: |-
+                      DisableWait disables waiting for all the resources to be deleted after
+                      a Helm uninstall is performed.
+                    type: boolean
+                  keepHistory:
+                    description: |-
+                      KeepHistory tells Helm to remove all associated resources and mark the
+                      release as deleted, but retain the release history.
+                    type: boolean
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation (like
+                      Jobs for hooks) during the performance of a Helm uninstall action. Defaults
+                      to 'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              upgrade:
+                description: |-
+                  Upgrade allows to overwrite the default upgrade options for the HelmRelease.
+                  Inherited from HelmRelease spec.
+                properties:
+                  cleanupOnFail:
+                    description: |-
+                      CleanupOnFail allows deletion of new resources created during the Helm
+                      upgrade action when it fails.
+                    type: boolean
+                  crds:
+                    description: |-
+                      CRDs upgrade CRDs from the Helm Chart's crds directory according
+                      to the CRD upgrade policy provided here. Valid values are `Skip`,
+                      `Create` or `CreateReplace`. Default is `Skip` and if omitted
+                      CRDs are neither installed nor upgraded.
+
+                      Skip: do neither install nor replace (update) any CRDs.
+
+                      Create: new CRDs are created, existing CRDs are neither updated nor deleted.
+
+                      CreateReplace: new CRDs are created, existing CRDs are updated (replaced)
+                      but not deleted.
+
+                      By default, CRDs are not applied during Helm upgrade action. With this
+                      option users can opt-in to CRD upgrade, which is not (yet) natively supported by Helm.
+                      https://helm.sh/docs/chart_best_practices/custom_resource_definitions.
+                    enum:
+                    - Skip
+                    - Create
+                    - CreateReplace
+                    type: string
+                  disableHooks:
+                    description: DisableHooks prevents hooks from running during the
+                      Helm upgrade action.
+                    type: boolean
+                  disableOpenAPIValidation:
+                    description: |-
+                      DisableOpenAPIValidation prevents the Helm upgrade action from validating
+                      rendered templates against the Kubernetes OpenAPI Schema.
+                    type: boolean
+                  disableSchemaValidation:
+                    description: |-
+                      DisableSchemaValidation prevents the Helm upgrade action from validating
+                      the values against the JSON Schema.
+                    type: boolean
+                  disableTakeOwnership:
+                    description: |-
+                      DisableTakeOwnership disables taking ownership of existing resources
+                      during the Helm upgrade action. Defaults to false.
+                    type: boolean
+                  disableWait:
+                    description: |-
+                      DisableWait disables the waiting for resources to be ready after a Helm
+                      upgrade has been performed.
+                    type: boolean
+                  disableWaitForJobs:
+                    description: |-
+                      DisableWaitForJobs disables waiting for jobs to complete after a Helm
+                      upgrade has been performed.
+                    type: boolean
+                  force:
+                    description: |-
+                      Force forces resource updates through a replacement strategy
+                      that avoids 3-way merge conflicts on client-side apply.
+                      This field is ignored for server-side apply (which always
+                      forces conflicts with other field managers).
+                    type: boolean
+                  preserveValues:
+                    description: |-
+                      PreserveValues will make Helm reuse the last release's values and merge in
+                      overrides from 'Values'. Setting this flag makes the HelmRelease
+                      non-declarative.
+                    type: boolean
+                  remediation:
+                    description: |-
+                      Remediation holds the remediation configuration for when the Helm upgrade
+                      action for the HelmRelease fails. The default is to not perform any action.
+                    properties:
+                      ignoreTestFailures:
+                        description: |-
+                          IgnoreTestFailures tells the controller to skip remediation when the Helm
+                          tests are run after an upgrade action but fail.
+                          Defaults to 'Test.IgnoreFailures'.
+                        type: boolean
+                      remediateLastFailure:
+                        description: |-
+                          RemediateLastFailure tells the controller to remediate the last failure, when
+                          no retries remain. Defaults to 'false' unless 'Retries' is greater than 0.
+                        type: boolean
+                      retries:
+                        description: |-
+                          Retries is the number of retries that should be attempted on failures before
+                          bailing. Remediation, using 'Strategy', is performed between each attempt.
+                          Defaults to '0', a negative integer equals to unlimited retries.
+                        type: integer
+                      strategy:
+                        description: Strategy to use for failure remediation. Defaults
+                          to 'rollback'.
+                        enum:
+                        - rollback
+                        - uninstall
+                        type: string
+                    type: object
+                  serverSideApply:
+                    description: |-
+                      ServerSideApply enables server-side apply for resources during upgrade.
+                      Can be "enabled", "disabled", or "auto".
+                      When "auto", server-side apply usage will be based on the release's previous usage.
+                      Defaults to "auto".
+                    enum:
+                    - enabled
+                    - disabled
+                    - auto
+                    type: string
+                  strategy:
+                    description: |-
+                      Strategy defines the upgrade strategy to use for this HelmRelease.
+                      Defaults to 'RemediateOnFailure', or 'RetryOnFailure' when the
+                      DefaultToRetryOnFailure feature gate is enabled.
+                    properties:
+                      name:
+                        description: Name of the upgrade strategy.
+                        enum:
+                        - RemediateOnFailure
+                        - RetryOnFailure
+                        type: string
+                      retryInterval:
+                        description: |-
+                          RetryInterval is the interval at which to retry a failed upgrade.
+                          Can be used only when Name is set to RetryOnFailure.
+                          Defaults to '5m'.
+                        pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                        type: string
+                    required:
+                    - name
+                    type: object
+                    x-kubernetes-validations:
+                    - message: .retryInterval can only be set when .name is 'RetryOnFailure'
+                      rule: '!has(self.retryInterval) || self.name == ''RetryOnFailure'''
+                  timeout:
+                    description: |-
+                      Timeout is the time to wait for any individual Kubernetes operation (like
+                      Jobs for hooks) during the performance of a Helm upgrade action. Defaults to
+                      'HelmReleaseSpec.Timeout'.
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              waitStrategy:
+                description: |-
+                  WaitStrategy allows to specify the HelmRelease's wait strategy.
+                  Inherited from HelmRelease spec.
+                properties:
+                  name:
+                    description: |-
+                      Name is Helm's wait strategy for waiting for applied resources to
+                      become ready. One of 'poller' or 'legacy'. The 'poller' strategy uses
+                      kstatus to poll resource statuses, while the 'legacy' strategy uses
+                      Helm v3's waiting logic.
+                      Defaults to 'poller', or to 'legacy' when UseHelm3Defaults feature
+                      gate is enabled.
+                    enum:
+                    - poller
+                    - legacy
+                    type: string
+                required:
+                - name
+                type: object
             required:
             - chartSource
             - namespace

--- a/api/go.mod
+++ b/api/go.mod
@@ -5,6 +5,7 @@ go 1.26.2
 require (
 	github.com/fluxcd/helm-controller/api v1.5.5
 	github.com/fluxcd/source-controller/api v1.8.5
+	github.com/fluxcd/pkg/apis/kustomize v1.18.0
 	github.com/openmcp-project/controller-utils v0.29.0
 	k8s.io/api v0.36.1
 	k8s.io/apiextensions-apiserver v0.36.1
@@ -20,7 +21,6 @@ require (
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/fluxcd/pkg/apis/acl v0.9.0 // indirect
-	github.com/fluxcd/pkg/apis/kustomize v1.18.0 // indirect
 	github.com/fluxcd/pkg/apis/meta v1.25.1 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.2 // indirect

--- a/api/go.mod
+++ b/api/go.mod
@@ -4,8 +4,8 @@ go 1.26.2
 
 require (
 	github.com/fluxcd/helm-controller/api v1.5.5
-	github.com/fluxcd/source-controller/api v1.8.5
 	github.com/fluxcd/pkg/apis/kustomize v1.18.0
+	github.com/fluxcd/source-controller/api v1.8.5
 	github.com/openmcp-project/controller-utils v0.29.0
 	k8s.io/api v0.36.1
 	k8s.io/apiextensions-apiserver v0.36.1

--- a/api/helm/v1alpha1/deploy_types.go
+++ b/api/helm/v1alpha1/deploy_types.go
@@ -6,6 +6,8 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	fluxhelmv2 "github.com/fluxcd/helm-controller/api/v2"
+	"github.com/fluxcd/pkg/apis/kustomize"
 	fluxv1 "github.com/fluxcd/source-controller/api/v1"
 
 	clustersv1alpha1 "github.com/openmcp-project/openmcp-operator/api/clusters/v1alpha1"
@@ -35,7 +37,7 @@ type HelmDeploymentSpec struct {
 	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
 	Namespace string `json:"namespace"`
 
-	// HelmValues are the helm values to deploy external-dns with, if the purpose selector matches.
+	// HelmValues are the helm values to deploy the chart with.
 	// There are a few special strings which will be replaced before creating the HelmRelease:
 	// - <provider.name> will be replaced with the provider name resource.
 	// - <provider.namespace> will be replaced with the namespace that hosts the platform service.
@@ -49,6 +51,70 @@ type HelmDeploymentSpec struct {
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +optional
 	HelmValues *apiextensionsv1.JSON `json:"helmValues,omitempty"`
+
+	// Interval at which to reconcile the Helm release.
+	// It can be used to overwrite the default reconciliation interval specified in the provider config.
+	// Inherited from HelmRelease spec.
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$"
+	// +optional
+	Interval *metav1.Duration `json:"interval,omitempty"`
+
+	// ReleaseName used for the Helm release.
+	// Defaults to <namespace>--<name>--<hash> (shortened to 63 characters) if not set.
+	// Inherited from HelmRelease spec.
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=53
+	// +optional
+	ReleaseName string `json:"releaseName,omitempty"`
+
+	// Timeout to set for the HelmRelease.
+	// Flux defaults this to 5 minutes, if not overwritten here.
+	// Inherited from HelmRelease spec.
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$"
+	// +optional
+	Timeout *metav1.Duration `json:"timeout,omitempty"`
+
+	// Install allows to overwrite the default install options for the HelmRelease.
+	// Inherited from HelmRelease spec.
+	// +optional
+	Install *fluxhelmv2.Install `json:"install,omitempty"`
+
+	// Upgrade allows to overwrite the default upgrade options for the HelmRelease.
+	// Inherited from HelmRelease spec.
+	// +optional
+	Upgrade *fluxhelmv2.Upgrade `json:"upgrade,omitempty"`
+
+	// Test allows to overwrite the default test options for the HelmRelease.
+	// Inherited from HelmRelease spec.
+	// +optional
+	Test *fluxhelmv2.Test `json:"test,omitempty"`
+
+	// Rollback allows to overwrite the default rollback options for the HelmRelease.
+	// Inherited from HelmRelease spec.
+	// +optional
+	Rollback *fluxhelmv2.Rollback `json:"rollback,omitempty"`
+
+	// Uninstall allows to overwrite the default uninstall options for the HelmRelease.
+	// Inherited from HelmRelease spec.
+	// +optional
+	Uninstall *fluxhelmv2.Uninstall `json:"uninstall,omitempty"`
+
+	// CommonMetadata allows to specify common metadata for the HelmRelease, e.g. labels and annotations.
+	// Inherited from HelmRelease spec.
+	// +optional
+	CommonMetadata *fluxhelmv2.CommonMetadata `json:"commonMetadata,omitempty"`
+
+	// WaitStrategy allows to specify the HelmRelease's wait strategy.
+	// Inherited from HelmRelease spec.
+	// +optional
+	WaitStrategy *fluxhelmv2.WaitStrategy `json:"waitStrategy,omitempty"`
+
+	// HealthCheckExprs allows to specify custom health checks for the HelmRelease.
+	// Inherited from HelmRelease spec.
+	// +optional
+	HealthCheckExprs []kustomize.CustomHealthCheck `json:"healthCheckExprs,omitempty"`
 }
 
 type SelectorOrReference struct {

--- a/api/helm/v1alpha1/zz_generated.deepcopy.go
+++ b/api/helm/v1alpha1/zz_generated.deepcopy.go
@@ -5,6 +5,8 @@
 package v1alpha1
 
 import (
+	v2 "github.com/fluxcd/helm-controller/api/v2"
+	"github.com/fluxcd/pkg/apis/kustomize"
 	apiv1 "github.com/fluxcd/source-controller/api/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -202,6 +204,56 @@ func (in *HelmDeploymentSpec) DeepCopyInto(out *HelmDeploymentSpec) {
 		in, out := &in.HelmValues, &out.HelmValues
 		*out = new(apiextensionsv1.JSON)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.Interval != nil {
+		in, out := &in.Interval, &out.Interval
+		*out = new(v1.Duration)
+		**out = **in
+	}
+	if in.Timeout != nil {
+		in, out := &in.Timeout, &out.Timeout
+		*out = new(v1.Duration)
+		**out = **in
+	}
+	if in.Install != nil {
+		in, out := &in.Install, &out.Install
+		*out = new(v2.Install)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.Upgrade != nil {
+		in, out := &in.Upgrade, &out.Upgrade
+		*out = new(v2.Upgrade)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.Test != nil {
+		in, out := &in.Test, &out.Test
+		*out = new(v2.Test)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.Rollback != nil {
+		in, out := &in.Rollback, &out.Rollback
+		*out = new(v2.Rollback)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.Uninstall != nil {
+		in, out := &in.Uninstall, &out.Uninstall
+		*out = new(v2.Uninstall)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.CommonMetadata != nil {
+		in, out := &in.CommonMetadata, &out.CommonMetadata
+		*out = new(v2.CommonMetadata)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.WaitStrategy != nil {
+		in, out := &in.WaitStrategy, &out.WaitStrategy
+		*out = new(v2.WaitStrategy)
+		**out = **in
+	}
+	if in.HealthCheckExprs != nil {
+		in, out := &in.HealthCheckExprs, &out.HealthCheckExprs
+		*out = make([]kustomize.CustomHealthCheck, len(*in))
+		copy(*out, *in)
 	}
 }
 

--- a/docs/controller/helmdeployer.md
+++ b/docs/controller/helmdeployer.md
@@ -76,6 +76,17 @@ spec:
     my-other-helm-value:
       this-is-nested: '<environment>'
       this-is-too: foo
+  interval: 5m # optional, can be used to overwrite default from provider config
+  releaseName: <...> # optional, can be used to overwrite default release name
+  timeout: 5m # optional, forwarded to HelmRelease spec
+  install: <...> # optional, forwarded to HelmRelease spec
+  upgrade: <...> # optional, forwarded to HelmRelease spec
+  test: <...> # optional, forwarded to HelmRelease spec
+  rollback: <...> # optional, forwarded to HelmRelease spec
+  uninstall: <...> # optional, forwarded to HelmRelease spec
+  commonMetadata: <...> # optional, forwarded to HelmRelease spec
+  waitStrategy: <...> # optional, forwarded to HelmRelease spec
+  healthCheckExprs: <...> # optional, forwarded to HelmRelease spec
   secretsToCopy: # optional
     toPlatformCluster: # optional
     - source:
@@ -125,6 +136,10 @@ Since some parts of the helm values could potentially depend on dynamic variable
 - `<helm.namespace>` => namespace of the `HelmDeployment`
 - `<cluster.name>` => name of the `Cluster` the chart is deployed onto
 - `<cluster.namespace>` => namespace of the `Cluster` the chart is deployed onto
+
+#### HelmRelease Specification
+
+The fields `interval`, `releaseName`, `timeout`, `install`, `upgrade`, `test`, `rollback`, `uninstall`, `commonMetadata`, `waitStrategy`, and `healthCheckExprs` are taken over from the spec of flux' `HelmRelease` resource and will be forwarded to their corresponding sections in the generated `HelmRelease`. `interval` and `releaseName` will be defaulted by the helm deployer, if not set, everything else is passed over as-is, leaving the defaulting to flux.
 
 #### Secret Copying
 

--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ replace (
 
 require (
 	dario.cat/mergo v1.0.2
-	github.com/fluxcd/pkg/apis/meta v1.28.0
 	github.com/fluxcd/pkg/apis/kustomize v1.18.0
+	github.com/fluxcd/pkg/apis/meta v1.28.0
 	github.com/onsi/ginkgo/v2 v2.29.0
 	github.com/onsi/gomega v1.41.0
 	github.com/openmcp-project/controller-utils v0.29.0

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ replace (
 require (
 	dario.cat/mergo v1.0.2
 	github.com/fluxcd/pkg/apis/meta v1.28.0
+	github.com/fluxcd/pkg/apis/kustomize v1.18.0
 	github.com/onsi/ginkgo/v2 v2.29.0
 	github.com/onsi/gomega v1.41.0
 	github.com/openmcp-project/controller-utils v0.29.0
@@ -29,7 +30,6 @@ require (
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/fluxcd/pkg/apis/acl v0.9.0 // indirect
-	github.com/fluxcd/pkg/apis/kustomize v1.18.0 // indirect
 	github.com/go-openapi/swag/cmdutils v0.26.0 // indirect
 	github.com/go-openapi/swag/conv v0.26.0 // indirect
 	github.com/go-openapi/swag/fileutils v0.26.0 // indirect

--- a/internal/controllers/helm/controller_test.go
+++ b/internal/controllers/helm/controller_test.go
@@ -788,6 +788,36 @@ var _ = Describe("HelmDeployment Controller", func() {
 		}, Equal(cconst.ReasonConfigurationProblem)))
 	})
 
+	It("should forward all customizable spec fields to the generated HelmRelease", func() {
+		env, cq, _ := defaultTestSetup("testdata", "test-06")
+
+		hd := &helmv1alpha1.HelmDeployment{}
+		hd.Name = "hd-0"
+		hd.Namespace = "default"
+		hdreq := testutils.RequestFromObject(hd)
+		Expect(env.Client(platform).Get(env.Ctx, client.ObjectKeyFromObject(hd), hd)).To(Succeed())
+
+		mimicControllers(env, hdreq, cq)
+
+		// fetch the generated HelmRelease
+		hrList := &fluxhelmv2.HelmReleaseList{}
+		Expect(env.Client(platform).List(env.Ctx, hrList)).To(Succeed())
+		Expect(hrList.Items).To(HaveLen(1))
+		hr := hrList.Items[0]
+
+		Expect(hr.Spec.ReleaseName).To(Equal(hd.Spec.ReleaseName))
+		Expect(hr.Spec.Interval).To(Equal(*hd.Spec.Interval))
+		Expect(hr.Spec.Timeout).To(Equal(hd.Spec.Timeout))
+		Expect(hr.Spec.Install).To(Equal(hd.Spec.Install))
+		Expect(hr.Spec.Upgrade).To(Equal(hd.Spec.Upgrade))
+		Expect(hr.Spec.Test).To(Equal(hd.Spec.Test))
+		Expect(hr.Spec.Rollback).To(Equal(hd.Spec.Rollback))
+		Expect(hr.Spec.Uninstall).To(Equal(hd.Spec.Uninstall))
+		Expect(hr.Spec.CommonMetadata).To(Equal(hd.Spec.CommonMetadata))
+		Expect(hr.Spec.WaitStrategy).To(Equal(hd.Spec.WaitStrategy))
+		Expect(hr.Spec.HealthCheckExprs).To(Equal(hd.Spec.HealthCheckExprs))
+	})
+
 	It("should copy secrets correctly", func() {
 		env, cq, fakeClients := defaultTestSetup("testdata", "test-05")
 

--- a/internal/controllers/helm/helm.go
+++ b/internal/controllers/helm/helm.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	fluxhelmv2 "github.com/fluxcd/helm-controller/api/v2"
+	"github.com/fluxcd/pkg/apis/kustomize"
 	fluxmeta "github.com/fluxcd/pkg/apis/meta"
 	fluxsourcev1 "github.com/fluxcd/source-controller/api/v1"
 
@@ -202,7 +203,11 @@ func (c *HelmDeploymentController) deployHelmRelease(ctx context.Context, cluste
 			}
 		}
 		// release information
-		hr.Spec.ReleaseName = ctrlutils.ShortenToXCharactersUnsafe(fmt.Sprintf("%s--%s--%s", rr.Object.Namespace, rr.Object.Name, ctrlutils.NameHashSHAKE128Base32(rr.Object.Namespace, rr.Object.Name)), ctrlutils.K8sMaxNameLength)
+		if len(rr.Object.Spec.ReleaseName) > 0 {
+			hr.Spec.ReleaseName = rr.Object.Spec.ReleaseName
+		} else {
+			hr.Spec.ReleaseName = ctrlutils.ShortenToXCharactersUnsafe(fmt.Sprintf("%s--%s--%s", rr.Object.Namespace, rr.Object.Name, ctrlutils.NameHashSHAKE128Base32(rr.Object.Namespace, rr.Object.Name)), ctrlutils.K8sMaxNameLength)
+		}
 		hr.Spec.TargetNamespace = rr.Object.Spec.Namespace
 		hr.Spec.StorageNamespace = rr.Object.Spec.Namespace
 		// values
@@ -218,26 +223,6 @@ func (c *HelmDeploymentController) deployHelmRelease(ctx context.Context, cluste
 			values = strings.ReplaceAll(values, fmt.Sprintf("%scluster.name%s", "\\u003c", "\\u003e"), cluster.Name)
 			hr.Spec.Values = &apiextensionsv1.JSON{Raw: []byte(values)}
 		}
-		// install configuration
-		if hr.Spec.Install == nil {
-			hr.Spec.Install = &fluxhelmv2.Install{
-				CreateNamespace: true,
-			}
-		}
-		hr.Spec.Install.CRDs = fluxhelmv2.CreateReplace
-		if hr.Spec.Install.Remediation == nil {
-			hr.Spec.Install.Remediation = &fluxhelmv2.InstallRemediation{}
-		}
-		hr.Spec.Install.Remediation.Retries = 3
-		// upgrade configuration
-		if hr.Spec.Upgrade == nil {
-			hr.Spec.Upgrade = &fluxhelmv2.Upgrade{}
-		}
-		hr.Spec.Upgrade.CRDs = fluxhelmv2.CreateReplace
-		if hr.Spec.Upgrade.Remediation == nil {
-			hr.Spec.Upgrade.Remediation = &fluxhelmv2.UpgradeRemediation{}
-		}
-		hr.Spec.Upgrade.Remediation.Retries = 3
 		// reference Cluster kubeconfig
 		hr.Spec.KubeConfig = &fluxmeta.KubeConfigReference{
 			SecretRef: &fluxmeta.SecretKeyReference{
@@ -245,8 +230,24 @@ func (c *HelmDeploymentController) deployHelmRelease(ctx context.Context, cluste
 				Key:  clustersv1alpha1.SecretKeyKubeconfig,
 			},
 		}
-		// deploy interval
-		hr.Spec.Interval = rr.Config.Spec.HelmReleaseReconciliationIntervals.IntervalForSourceKind(rr.SourceKind)
+		// forward configuration to helm release
+		if rr.Object.Spec.Interval != nil {
+			hr.Spec.Interval = *rr.Object.Spec.Interval.DeepCopy()
+		} else {
+			hr.Spec.Interval = rr.Config.Spec.HelmReleaseReconciliationIntervals.IntervalForSourceKind(rr.SourceKind)
+		}
+		hr.Spec.Timeout = rr.Object.Spec.Timeout.DeepCopy()
+		hr.Spec.Install = rr.Object.Spec.Install.DeepCopy()
+		hr.Spec.Upgrade = rr.Object.Spec.Upgrade.DeepCopy()
+		hr.Spec.Test = rr.Object.Spec.Test.DeepCopy()
+		hr.Spec.Rollback = rr.Object.Spec.Rollback.DeepCopy()
+		hr.Spec.Uninstall = rr.Object.Spec.Uninstall.DeepCopy()
+		hr.Spec.CommonMetadata = rr.Object.Spec.CommonMetadata.DeepCopy()
+		hr.Spec.WaitStrategy = rr.Object.Spec.WaitStrategy.DeepCopy()
+		if len(rr.Object.Spec.HealthCheckExprs) > 0 {
+			hr.Spec.HealthCheckExprs = make([]kustomize.CustomHealthCheck, len(rr.Object.Spec.HealthCheckExprs))
+			copy(hr.Spec.HealthCheckExprs, rr.Object.Spec.HealthCheckExprs)
+		}
 		return nil
 	}); err != nil {
 		createConForCluster(metav1.ConditionFalse, helmv1alpha1.ReasonHelmReleaseDeploymentFailed, fmt.Sprintf("Error creating or updating HelmRelease '%s/%s': %s", hr.Namespace, hr.Name, err.Error()))

--- a/internal/controllers/helm/testdata/test-06/cluster-0.yaml
+++ b/internal/controllers/helm/testdata/test-06/cluster-0.yaml
@@ -1,0 +1,18 @@
+apiVersion: clusters.openmcp.cloud/v1alpha1
+kind: Cluster
+metadata:
+  labels:
+    helm.open-control-plane.io/target: "true"
+  finalizers:
+  - provider.clusters.openmcp.cloud/finalizer
+  name: cluster-0
+  namespace: default
+spec:
+  kubernetes: {}
+  profile: myprofile
+  purposes:
+  - workload
+  - single
+  tenancy: Shared
+status:
+  phase: Ready

--- a/internal/controllers/helm/testdata/test-06/hd-0.yaml
+++ b/internal/controllers/helm/testdata/test-06/hd-0.yaml
@@ -1,0 +1,40 @@
+apiVersion: helm.open-control-plane.io/v1alpha1
+kind: HelmDeployment
+metadata:
+  name: hd-0
+  namespace: default
+spec:
+  chartSource:
+    oci:
+      url: "oci://example.org/repo/charts"
+      interval: 10m
+  selector:
+    matchPurposes:
+    - operator: ContainsAll
+      values:
+      - single
+  namespace: helm
+  interval: 5m
+  releaseName: my-release
+  timeout: 3m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  test:
+    enable: true
+  rollback:
+    timeout: 2m
+  uninstall:
+    timeout: 2m
+  commonMetadata:
+    labels:
+      app: my-app
+  waitStrategy:
+    name: poller
+  healthCheckExprs:
+  - apiVersion: apps/v1
+    kind: Deployment
+    current: "health.isHealthy(self)"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds most of the spec fields of flux' `HelmRelease` resource to the spec of `HelmDeployment`, enabling fine-tuning of the generated `HelmRelease`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The `HelmDeployment` resource's `spec` now contains most fields of flux' `HelmRelease` resource's spec. They are forwarded to the generated `HelmRelease`, enabling better customization.
```
```breaking operator
Before the new fields were added to the `HelmDeployment`'s `spec`, the helm deployer would simply set some 'best guess' defaults. Now, the new fields are forwarded to the generated `HelmRelease` and some of the defaulting has been removed. To keep the same behavior, these fields need to be set in the `HelmDeployment`'s `spec` now. Primarily, the fields `crds` (defaulted to `CreateReplace` before) and `remediation.retries` (defaulted to `3` before) in both, `spec.install` and `spec.upgrade`, are affected.
```
