### PR TITLE
feat: add optional DisableAutomaticNamespaceCreation field to PermissionsRequest

### DIFF
--- a/api/clusters/v1alpha1/accessrequest_types.go
+++ b/api/clusters/v1alpha1/accessrequest_types.go
@@ -81,9 +81,14 @@ type PermissionsRequest struct {
 
 	// Namespace is the namespace for which the permissions are requested.
 	// If empty, this will result in a ClusterRole, otherwise in a Role in the respective namespace.
-	// Note that for a Role, the namespace needs to either exist or a permission to create it must be included in the requested permissions (it will be created automatically then), otherwise the request will be rejected.
+	// By default, the namespace will be created automatically if it does not exist unless DisableAutomaticNamespaceCreation is set to true.
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
+
+	// DisableAutomaticNamespaceCreation controls whether the target namespace is auto-created when Namespace is set and does not exist.
+	// Defaults to false.
+	// +optional
+	DisableAutomaticNamespaceCreation bool `json:"disableAutomaticNamespaceCreation,omitempty"`
 
 	// Rules are the requested RBAC rules.
 	Rules []rbacv1.PolicyRule `json:"rules"`

--- a/api/crds/manifests/clusters.openmcp.cloud_accessrequests.yaml
+++ b/api/crds/manifests/clusters.openmcp.cloud_accessrequests.yaml
@@ -198,6 +198,11 @@ spec:
                       It is strongly recommended to set the name field so that the created (Cluster)Roles can be referenced in the RoleBindings field.
                     items:
                       properties:
+                        disableAutomaticNamespaceCreation:
+                          description: |-
+                            DisableAutomaticNamespaceCreation controls whether the target namespace is auto-created when Namespace is set and does not exist.
+                            Defaults to false.
+                          type: boolean
                         name:
                           description: |-
                             Name is an optional name for the (Cluster)Role that will be created for the requested permissions.
@@ -208,7 +213,7 @@ spec:
                           description: |-
                             Namespace is the namespace for which the permissions are requested.
                             If empty, this will result in a ClusterRole, otherwise in a Role in the respective namespace.
-                            Note that for a Role, the namespace needs to either exist or a permission to create it must be included in the requested permissions (it will be created automatically then), otherwise the request will be rejected.
+                            By default, the namespace will be created automatically if it does not exist unless DisableAutomaticNamespaceCreation is set to true.
                           type: string
                         rules:
                           description: Rules are the requested RBAC rules.
@@ -314,6 +319,11 @@ spec:
                       The created serviceaccount will be bound to the created Roles and ClusterRoles.
                     items:
                       properties:
+                        disableAutomaticNamespaceCreation:
+                          description: |-
+                            DisableAutomaticNamespaceCreation controls whether the target namespace is auto-created when Namespace is set and does not exist.
+                            Defaults to false.
+                          type: boolean
                         name:
                           description: |-
                             Name is an optional name for the (Cluster)Role that will be created for the requested permissions.
@@ -324,7 +334,7 @@ spec:
                           description: |-
                             Namespace is the namespace for which the permissions are requested.
                             If empty, this will result in a ClusterRole, otherwise in a Role in the respective namespace.
-                            Note that for a Role, the namespace needs to either exist or a permission to create it must be included in the requested permissions (it will be created automatically then), otherwise the request will be rejected.
+                            By default, the namespace will be created automatically if it does not exist unless DisableAutomaticNamespaceCreation is set to true.
                           type: string
                         rules:
                           description: Rules are the requested RBAC rules.

--- a/api/crds/manifests/core.open-control-plane.io_controlplanes.yaml
+++ b/api/crds/manifests/core.open-control-plane.io_controlplanes.yaml
@@ -299,6 +299,11 @@ spec:
                             The created serviceaccount will be bound to the created Roles and ClusterRoles.
                           items:
                             properties:
+                              disableAutomaticNamespaceCreation:
+                                description: |-
+                                  DisableAutomaticNamespaceCreation controls whether the target namespace is auto-created when Namespace is set and does not exist.
+                                  Defaults to false.
+                                type: boolean
                               name:
                                 description: |-
                                   Name is an optional name for the (Cluster)Role that will be created for the requested permissions.
@@ -309,7 +314,7 @@ spec:
                                 description: |-
                                   Namespace is the namespace for which the permissions are requested.
                                   If empty, this will result in a ClusterRole, otherwise in a Role in the respective namespace.
-                                  Note that for a Role, the namespace needs to either exist or a permission to create it must be included in the requested permissions (it will be created automatically then), otherwise the request will be rejected.
+                                  By default, the namespace will be created automatically if it does not exist unless DisableAutomaticNamespaceCreation is set to true.
                                 type: string
                               rules:
                                 description: Rules are the requested RBAC rules.


### PR DESCRIPTION
On-behalf-of: @SAP nico.andres@sap.com

**What this PR does / why we need it**:
Adds optional `DisableAutomaticNamespaceCreation` field to `PermissionsRequest`

**Which issue(s) this PR fixes**:
Related to https://github.com/openmcp-project/openmcp-operator/issues/282

**Special notes for your reviewer**:
I placed it in `PermissionsRequest`. With that the optional flag can be set on a per role basis which gives us the highest level of flexibility if needed.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Adds `DisableAutomaticNamespaceCreation` field to `PermissionsRequest` to optionally disable automated namespace creation by the cluster provider
```
