### PR TITLE
feat: add and propagate metadata annotations/labels

### DIFF
--- a/api/constants/constants.go
+++ b/api/constants/constants.go
@@ -3,6 +3,8 @@ package constants
 const (
 	// OpenMCPGroupName is the base API group name for OpenMCP.
 	OpenMCPGroupName = "openmcp.cloud"
+	// OCPGroupName is the new group name.
+	OCPGroupName = "open-control-plane.io"
 
 	// ClusterLabel can be used on CRDs to indicate onto which cluster they should be deployed.
 	ClusterLabel = OpenMCPGroupName + "/cluster"
@@ -58,4 +60,8 @@ const (
 	MetricsPortAnnotation = MetricsPrometheusAnnotation + "/port"
 	// MetricsPathAnnotation defines the metrics path annotation
 	MetricsPathAnnotation = MetricsPrometheusAnnotation + "/path"
+
+	// MetadataAnnotationLabelPrefix is a prefix for metadata annotations/labels.
+	// Annotations and labels with this prefix are propagated between resources in some cases, e.g. from ClusterRequests to the corresponding Cluster resources (for exclusive clusters only).
+	MetadataAnnotationLabelPrefix = "metadata." + OCPGroupName + "/"
 )

--- a/api/constants/constants.go
+++ b/api/constants/constants.go
@@ -3,8 +3,8 @@ package constants
 const (
 	// OpenMCPGroupName is the base API group name for OpenMCP.
 	OpenMCPGroupName = "openmcp.cloud"
-	// OCPGroupName is the new group name.
-	OCPGroupName = "open-control-plane.io"
+	// OpenControlPlaneGroup is the new group name.
+	OpenControlPlaneGroup = "open-control-plane.io"
 
 	// ClusterLabel can be used on CRDs to indicate onto which cluster they should be deployed.
 	ClusterLabel = OpenMCPGroupName + "/cluster"
@@ -63,5 +63,5 @@ const (
 
 	// MetadataAnnotationLabelPrefix is a prefix for metadata annotations/labels.
 	// Annotations and labels with this prefix are propagated between resources in some cases, e.g. from ClusterRequests to the corresponding Cluster resources (for exclusive clusters only).
-	MetadataAnnotationLabelPrefix = "metadata." + OCPGroupName + "/"
+	MetadataAnnotationLabelPrefix = "metadata." + OpenControlPlaneGroup + "/"
 )

--- a/internal/controllers/controlplane/controller.go
+++ b/internal/controllers/controlplane/controller.go
@@ -3,6 +3,7 @@ package controlplane
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"strings"
 	"time"
@@ -15,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/events"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -251,8 +251,27 @@ func (r *ManagedControlPlaneReconciler) handleCreateOrUpdate(ctx context.Context
 	}
 	createCon(corev2alpha1.ConditionMeta, metav1.ConditionTrue, "", "")
 
+	metadataLabels := map[string]string{
+		apiconst.MetadataAnnotationLabelPrefix + "cp-name":      mcp.Name,
+		apiconst.MetadataAnnotationLabelPrefix + "cp-namespace": mcp.Namespace,
+	}
+	// try to fetch the CP's namespace to identify project and workspace, if any
+	cpNs := &corev1.Namespace{}
+	cpNs.Name = mcp.Namespace
+	if err := r.OnboardingCluster.Client().Get(ctx, client.ObjectKeyFromObject(cpNs), cpNs); err != nil {
+		// this is not critical, so just log the error and ignore it
+		log.Error(err, "Failed to get MCP namespace to fetch project and workspace labels", "namespace", mcp.Namespace)
+	} else {
+		// the hard-coded strings are ugly, but we don't want a dependency on the project-workspace operator in here
+		if project, ok := cpNs.Labels["core.openmcp.cloud/project"]; ok {
+			metadataLabels[apiconst.MetadataAnnotationLabelPrefix+"project"] = project
+		}
+		if workspace, ok := cpNs.Labels["core.openmcp.cloud/workspace"]; ok {
+			metadataLabels[apiconst.MetadataAnnotationLabelPrefix+"workspace"] = workspace
+		}
+	}
+
 	// ensure that the ClusterRequest exists
-	// since ClusterRequests are basically immutable, updating them is not required
 	cr := &clustersv1alpha1.ClusterRequest{}
 	cr.Name = mcp.Name
 	cr.Namespace = platformNamespace
@@ -271,9 +290,10 @@ func (r *ManagedControlPlaneReconciler) handleCreateOrUpdate(ctx context.Context
 
 		log.Info("ClusterRequest not found, creating it", "clusterRequestName", cr.Name, "clusterRequestNamespace", cr.Namespace, "purpose", purpose)
 		cr.Labels = mcpLabels
+		maps.Copy(cr.Labels, metadataLabels)
 		cr.Spec = clustersv1alpha1.ClusterRequestSpec{
 			Purpose:                purpose,
-			WaitForClusterDeletion: ptr.To(true),
+			WaitForClusterDeletion: new(true),
 		}
 		if err := r.PlatformCluster.Client().Create(ctx, cr); err != nil {
 			rr.ReconcileError = errutils.WithReason(fmt.Errorf("error creating ClusterRequest '%s/%s': %w", cr.Namespace, cr.Name, err), cconst.ReasonPlatformClusterInteractionProblem)
@@ -282,6 +302,25 @@ func (r *ManagedControlPlaneReconciler) handleCreateOrUpdate(ctx context.Context
 		}
 	} else {
 		log.Debug("ClusterRequest found", "clusterRequestName", cr.Name, "clusterRequestNamespace", cr.Namespace, "configuredPurpose", purpose, "purposeInClusterRequest", cr.Spec.Purpose)
+
+		// check if the metadata labels need to be updated
+		// this should not really happen, unless the CP's namespace could not be fetched during the initial creation
+		// The spec of the ClusterRequest is basically immutable, updating it is not possible.
+		update := false
+		for k, expectedValue := range metadataLabels {
+			if cr.Labels[k] != expectedValue {
+				update = true
+				cr.Labels[k] = expectedValue
+			}
+		}
+		if update {
+			log.Info("Updating ClusterRequest to add missing or outdated metadata labels", "clusterRequestName", cr.Name, "clusterRequestNamespace", cr.Namespace)
+			if err := r.PlatformCluster.Client().Update(ctx, cr); err != nil {
+				rr.ReconcileError = errutils.WithReason(fmt.Errorf("error updating ClusterRequest '%s/%s' to add missing or outdated metadata labels: %w", cr.Namespace, cr.Name, err), cconst.ReasonPlatformClusterInteractionProblem)
+				createCon(corev2alpha1.ConditionClusterRequestReady, metav1.ConditionFalse, rr.ReconcileError.Reason(), rr.ReconcileError.Error())
+				return rr
+			}
+		}
 	}
 
 	// check if the ClusterRequest is ready
@@ -365,7 +404,7 @@ func (r *ManagedControlPlaneReconciler) handleDelete(ctx context.Context, mcp *c
 			*agg.Key = append(*agg.Key, service)
 			agg.Value += len(resources)
 			return agg
-		}, pairs.New(ptr.To([]string{}), 0))
+		}, pairs.New(new([]string{}), 0))
 		log.Info("Waiting for service resources to be deleted", "services", strings.Join(*serviceResourceCount.Key, ", "), "remainingResourcesCount", serviceResourceCount.Value)
 		msg := strings.Builder{}
 		msg.WriteString("Waiting for the following service resources to be deleted: ")

--- a/internal/controllers/scheduler/controller.go
+++ b/internal/controllers/scheduler/controller.go
@@ -164,8 +164,33 @@ func (r *ClusterScheduler) handleCreateOrUpdate(ctx context.Context, req reconci
 					rr.ReconcileError = errutils.WithReason(fmt.Errorf("error patching finalizer '%s' on cluster '%s/%s': %w", fin, existingCluster.Namespace, existingCluster.Name, err), cconst.ReasonPlatformClusterInteractionProblem)
 					return rr
 				}
+			} else {
+				log.Info("Request already contains a reference to an existing cluster, nothing to do", "clusterName", cr.Status.Cluster.Name, "clusterNamespace", cr.Status.Cluster.Namespace)
 			}
-			log.Info("Request already contains a reference to an existing cluster, nothing to do", "clusterName", cr.Status.Cluster.Name, "clusterNamespace", cr.Status.Cluster.Namespace)
+			// if it's an exclusive cluster, propagate metadata annotations/labels from the ClusterRequest to the Cluster
+			if existingCluster.Spec.Tenancy == clustersv1alpha1.TENANCY_EXCLUSIVE {
+				update := false
+				oldCluster := existingCluster.DeepCopy()
+				for k, expectedValue := range cr.Annotations {
+					if strings.HasPrefix(k, apiconst.MetadataAnnotationLabelPrefix) && existingCluster.Annotations[k] != expectedValue {
+						update = true
+						existingCluster.Annotations[k] = expectedValue
+					}
+				}
+				for k, expectedValue := range cr.Labels {
+					if strings.HasPrefix(k, apiconst.MetadataAnnotationLabelPrefix) && existingCluster.Labels[k] != expectedValue {
+						update = true
+						existingCluster.Labels[k] = expectedValue
+					}
+				}
+				if update {
+					log.Info("Patching Cluster to add missing or outdated metadata annotations/labels", "clusterName", existingCluster.Name, "clusterNamespace", existingCluster.Namespace)
+					if err := r.PlatformCluster.Client().Patch(ctx, existingCluster, client.MergeFrom(oldCluster)); err != nil {
+						rr.ReconcileError = errutils.WithReason(fmt.Errorf("error patching Cluster '%s/%s' to add missing or outdated metadata annotations/labels: %w", existingCluster.Namespace, existingCluster.Name, err), cconst.ReasonPlatformClusterInteractionProblem)
+						return rr
+					}
+				}
+			}
 			return rr
 		} else if !apierrors.IsNotFound(err) {
 			rr.ReconcileError = errutils.WithReason(fmt.Errorf("error checking whether cluster '%s/%s' exists: %w", existingCluster.Namespace, existingCluster.Name, err), cconst.ReasonPlatformClusterInteractionProblem)
@@ -637,6 +662,25 @@ func (r *ClusterScheduler) initializeNewCluster(ctx context.Context, cr *cluster
 		}
 	}
 	cluster.SetAnnotations(cDef.Template.Annotations)
+	if cDef.Template.Spec.Tenancy == clustersv1alpha1.TENANCY_EXCLUSIVE {
+		// propagate metadata annotations/labels for exclusive clusters
+		if cluster.Labels == nil {
+			cluster.Labels = make(map[string]string, len(cr.Labels))
+		}
+		for k, v := range cr.Labels {
+			if strings.HasPrefix(k, apiconst.MetadataAnnotationLabelPrefix) {
+				cluster.Labels[k] = v
+			}
+		}
+		if cluster.Annotations == nil {
+			cluster.Annotations = make(map[string]string, len(cr.Annotations))
+		}
+		for k, v := range cr.Annotations {
+			if strings.HasPrefix(k, apiconst.MetadataAnnotationLabelPrefix) {
+				cluster.Annotations[k] = v
+			}
+		}
+	}
 	cluster.Spec = *cDef.Template.Spec.DeepCopy()
 
 	// set purpose, if not set

--- a/internal/controllers/scheduler/controller.go
+++ b/internal/controllers/scheduler/controller.go
@@ -10,6 +10,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -664,20 +665,14 @@ func (r *ClusterScheduler) initializeNewCluster(ctx context.Context, cr *cluster
 	cluster.SetAnnotations(cDef.Template.Annotations)
 	if cDef.Template.Spec.Tenancy == clustersv1alpha1.TENANCY_EXCLUSIVE {
 		// propagate metadata annotations/labels for exclusive clusters
-		if cluster.Labels == nil {
-			cluster.Labels = make(map[string]string, len(cr.Labels))
+		for k, v := range cr.Annotations {
+			if strings.HasPrefix(k, apiconst.MetadataAnnotationLabelPrefix) {
+				metav1.SetMetaDataAnnotation(&cluster.ObjectMeta, k, v)
+			}
 		}
 		for k, v := range cr.Labels {
 			if strings.HasPrefix(k, apiconst.MetadataAnnotationLabelPrefix) {
-				cluster.Labels[k] = v
-			}
-		}
-		if cluster.Annotations == nil {
-			cluster.Annotations = make(map[string]string, len(cr.Annotations))
-		}
-		for k, v := range cr.Annotations {
-			if strings.HasPrefix(k, apiconst.MetadataAnnotationLabelPrefix) {
-				cluster.Annotations[k] = v
+				metav1.SetMetaDataLabel(&cluster.ObjectMeta, k, v)
 			}
 		}
 	}

--- a/internal/controllers/scheduler/controller_test.go
+++ b/internal/controllers/scheduler/controller_test.go
@@ -22,6 +22,7 @@ import (
 	testutils "github.com/openmcp-project/controller-utils/pkg/testing"
 
 	clustersv1alpha1 "github.com/openmcp-project/openmcp-operator/api/clusters/v1alpha1"
+	apiconst "github.com/openmcp-project/openmcp-operator/api/constants"
 	"github.com/openmcp-project/openmcp-operator/api/install"
 	"github.com/openmcp-project/openmcp-operator/internal/config"
 	"github.com/openmcp-project/openmcp-operator/internal/controllers/scheduler"
@@ -594,6 +595,47 @@ var _ = Describe("Scheduler", func() {
 		Expect(newCluster.Name).To(Equal(req.Status.Cluster.Name))
 		Expect(newCluster.Namespace).To(Equal(clusterNamespace))
 		Expect(newCluster.Name).To(Equal(cluster.Name), "Recreated cluster should have the same name")
+	})
+
+	It("should propagate metadata annotations/labels from ClusterRequests to exclusive Clusters but not shared Clusters", func() {
+		env, _ := defaultTestSetup("testdata", "test-06")
+
+		// exclusive cluster should inherit the metadata annotations/labels
+		reqEx := &clustersv1alpha1.ClusterRequest{}
+		Expect(env.Client().Get(env.Ctx, ctrlutils.ObjectKey("exclusive", "foo"), reqEx)).To(Succeed())
+		Expect(reqEx.Status.Cluster).To(BeNil())
+
+		env.ShouldReconcile(testutils.RequestFromObject(reqEx))
+		Expect(env.Client().Get(env.Ctx, client.ObjectKeyFromObject(reqEx), reqEx)).To(Succeed())
+		Expect(reqEx.Status.Cluster).ToNot(BeNil())
+		clusterEx := &clustersv1alpha1.Cluster{}
+		Expect(env.Client().Get(env.Ctx, ctrlutils.ObjectKey(reqEx.Status.Cluster.Name, reqEx.Status.Cluster.Namespace), clusterEx)).To(Succeed())
+		Expect(clusterEx.Annotations).To(HaveKeyWithValue(apiconst.MetadataAnnotationLabelPrefix+"annotation", "foo"))
+		Expect(clusterEx.Annotations).To(HaveKeyWithValue(apiconst.MetadataAnnotationLabelPrefix+"annotation2", "foobar"))
+		Expect(clusterEx.Annotations).ToNot(HaveKey("foo.bar.baz/propagate"))
+		Expect(clusterEx.Labels).To(HaveKeyWithValue(apiconst.MetadataAnnotationLabelPrefix+"label", "bar"))
+		Expect(clusterEx.Labels).To(HaveKeyWithValue(apiconst.MetadataAnnotationLabelPrefix+"label2", "baz"))
+		Expect(clusterEx.Labels).ToNot(HaveKey("foo.bar.baz/propagate"))
+
+		// shared cluster should not inherit the metadata annotations/labels
+		reqSh := &clustersv1alpha1.ClusterRequest{}
+		Expect(env.Client().Get(env.Ctx, ctrlutils.ObjectKey("shared", "foo"), reqSh)).To(Succeed())
+		Expect(reqSh.Status.Cluster).To(BeNil())
+
+		env.ShouldReconcile(testutils.RequestFromObject(reqSh))
+		Expect(env.Client().Get(env.Ctx, client.ObjectKeyFromObject(reqSh), reqSh)).To(Succeed())
+		Expect(reqSh.Status.Cluster).ToNot(BeNil())
+		clusterSh := &clustersv1alpha1.Cluster{}
+		Expect(env.Client().Get(env.Ctx, ctrlutils.ObjectKey(reqSh.Status.Cluster.Name, reqSh.Status.Cluster.Namespace), clusterSh)).To(Succeed())
+		Expect(clusterSh.Annotations).ToNot(HaveKey(ContainSubstring(apiconst.MetadataAnnotationLabelPrefix)))
+		Expect(clusterSh.Labels).ToNot(HaveKey(ContainSubstring(apiconst.MetadataAnnotationLabelPrefix)))
+
+		// updating the labels on the request should update them on the exclusive cluster
+		reqEx.Labels[apiconst.MetadataAnnotationLabelPrefix+"new"] = "newvalue"
+		Expect(env.Client().Update(env.Ctx, reqEx)).To(Succeed())
+		env.ShouldReconcile(testutils.RequestFromObject(reqEx))
+		Expect(env.Client().Get(env.Ctx, ctrlutils.ObjectKey(reqEx.Status.Cluster.Name, reqEx.Status.Cluster.Namespace), clusterEx)).To(Succeed())
+		Expect(clusterEx.Labels).To(HaveKeyWithValue(apiconst.MetadataAnnotationLabelPrefix+"new", "newvalue"))
 	})
 
 })

--- a/internal/controllers/scheduler/testdata/test-06/cluster/req-0.yaml
+++ b/internal/controllers/scheduler/testdata/test-06/cluster/req-0.yaml
@@ -1,0 +1,16 @@
+apiVersion: clusters.openmcp.cloud/v1alpha1
+kind: ClusterRequest
+metadata:
+  name: exclusive
+  namespace: foo
+  uid: dc4b422b-8676-4bc0-951f-7a535d790c04
+  annotations:
+    metadata.open-control-plane.io/annotation: "foo"
+    metadata.open-control-plane.io/annotation2: "foobar"
+    foo.bar.baz/propagate: "false"
+  labels:
+    metadata.open-control-plane.io/label: "bar"
+    metadata.open-control-plane.io/label2: "baz"
+    foo.bar.baz/propagate: "false"
+spec:
+  purpose: exclusive

--- a/internal/controllers/scheduler/testdata/test-06/cluster/req-1.yaml
+++ b/internal/controllers/scheduler/testdata/test-06/cluster/req-1.yaml
@@ -1,0 +1,14 @@
+apiVersion: clusters.openmcp.cloud/v1alpha1
+kind: ClusterRequest
+metadata:
+  name: shared
+  namespace: foo
+  uid: 4d6aa495-54c0-4df2-bc7b-05b103f02e69
+  annotations:
+    metadata.open-control-plane.io/annotation: "foo"
+    metadata.open-control-plane.io/annotation2: "foobar"
+  labels:
+    metadata.open-control-plane.io/label: "bar"
+    metadata.open-control-plane.io/label2: "baz"
+spec:
+  purpose: shared-twice

--- a/internal/controllers/scheduler/testdata/test-06/config.yaml
+++ b/internal/controllers/scheduler/testdata/test-06/config.yaml
@@ -1,0 +1,25 @@
+scheduler:
+  scope: Cluster
+  purposeMappings:
+    exclusive:
+      template:
+        metadata:
+          namespace: exclusive
+        spec:
+          profile: test-profile
+          tenancy: Exclusive
+    shared-unlimited:
+      template:
+        metadata:
+          namespace: shared-unlimited
+        spec:
+          profile: test-profile
+          tenancy: Shared
+    shared-twice:
+      tenancyCount: 2
+      template:
+        metadata:
+          namespace: shared-twice
+        spec:
+          profile: test-profile
+          tenancy: Shared


### PR DESCRIPTION
**What this PR does / why we need it**:
Annotations and labels with the prefix `metadata.open-control-plane.io/` are now propagated from `ClusterRequest` resources to their corresponding `Cluster` resources (for 'exclusive' clusters only, as 'shared' ones are shared between multiple requests, which would cause conflicts). Requests belonging to a `ControlPlane` will receive metadata labels containing the corresponding CP's name, namespace, and, if applicable, project and workspace.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
This allows us to propagate this metadata information onto the `Shoot` resources (requires a follow-up PR in the Gardener ClusterProvider), from where it could be displayed in the Gardener Dashboard.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Annotations and labels with the prefix `metadata.open-control-plane.io/` are now propagated from `ClusterRequest` resources to their corresponding `Cluster` resources (for 'exclusive' clusters only, as 'shared' ones are shared between multiple requests, which would cause conflicts). Requests belonging to a `ControlPlane` will receive metadata labels containing the corresponding CP's name, namespace, and, if applicable, project and workspace.
```
