### PR TITLE
feat(common): add list type map to `Conditions` field in `Status` API

### DIFF
--- a/api/common/status_types.go
+++ b/api/common/status_types.go
@@ -20,6 +20,8 @@ type Status struct {
 	Phase string `json:"phase"`
 
 	// Conditions contains the conditions.
+	// +listType=map
+	// +listMapKey=type
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }

--- a/api/crds/manifests/clusters.openmcp.cloud_accessrequests.yaml
+++ b/api/crds/manifests/clusters.openmcp.cloud_accessrequests.yaml
@@ -497,6 +497,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: ObservedGeneration is the generation of this resource
                   that was last reconciled by the controller.

--- a/api/crds/manifests/clusters.openmcp.cloud_clusterrequests.yaml
+++ b/api/crds/manifests/clusters.openmcp.cloud_clusterrequests.yaml
@@ -152,6 +152,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: ObservedGeneration is the generation of this resource
                   that was last reconciled by the controller.

--- a/api/crds/manifests/clusters.openmcp.cloud_clusters.yaml
+++ b/api/crds/manifests/clusters.openmcp.cloud_clusters.yaml
@@ -182,6 +182,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               endpoints:
                 description: Endpoints is a list of endpoints for the cluster.
                 items:

--- a/api/crds/manifests/core.open-control-plane.io_controlplanes.yaml
+++ b/api/crds/manifests/core.open-control-plane.io_controlplanes.yaml
@@ -490,6 +490,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               endpoints:
                 description: Endpoints is a list of exposed Cluster endpoints.
                 items:

--- a/api/crds/manifests/helm.open-control-plane.io_helmdeployments.yaml
+++ b/api/crds/manifests/helm.open-control-plane.io_helmdeployments.yaml
@@ -1419,6 +1419,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: ObservedGeneration is the generation of this resource
                   that was last reconciled by the controller.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the list type map to the `commonapi.Status.Conditions` field. By default, in kubebuilder all conditions are list type map too, see:

```go
// CronJobStatus defines the observed state of CronJob.
type CronJobStatus struct {
	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
	// Important: Run "make" to regenerate code after modifying this file

	// For Kubernetes API conventions, see:
	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties

	// conditions represent the current state of the CronJob resource.
	// Each condition has a unique type and reflects the status of a specific aspect of the resource.
	//
	// Standard condition types include:
	// - "Available": the resource is fully functional
	// - "Progressing": the resource is being created or updated
	// - "Degraded": the resource failed to reach or maintain its desired state
	//
	// The status of each condition is one of True, False, or Unknown.
	// +listType=map
	// +listMapKey=type
	// +optional
	Conditions []metav1.Condition `json:"conditions,omitempty"`
}
```

This makes sure that only one type with exactly this name can exist in the array (no duplicates).

Our service providers should use `commonapi.Status` struct as well but can not since these fields are missing here. E.g. service-provider-flux is using this as well: https://github.com/openmcp-project/service-provider-flux/blob/main/api/v1alpha1/providerconfig_types.go#L114-L115

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Add list type map to status condition array 
```
