### PR TITLE
chore(deps): renovate org-preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>openmcp-project/.github:renovate-config"
+  ],
   "git-submodules": {
     "enabled": true
   },
@@ -7,29 +10,7 @@
   "gitIgnoredAuthors": [
     "github-actions[bot]@users.noreply.github.com"
   ],
-  "extends": [
-    "config:recommended",
-    "config:best-practices",
-    "security:openssf-scorecard",
-    "helpers:pinGitHubActionDigests",
-    ":rebaseStalePrs"
-  ],
-  "postUpdateOptions": [
-    "gomodTidy"
-  ],
   "packageRules": [
-    {
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchDepNames": [
-        "go"
-      ],
-      "matchDepTypes": [
-        "golang"
-      ],
-      "rangeStrategy": "bump"
-    },
     {
       "description": "Automerge submodule update",
       "automerge": true,
@@ -56,14 +37,6 @@
         "github.com/fluxcd/**"
       ],
       "groupName": "fluxcd packages"
-    },
-    {
-      "description": "Group openmcp-project/build submodule and workflow updates",
-      "matchDepNames": [
-        "hack/common",
-        "openmcp-project/build"
-      ],
-      "groupName": "openmcp-project/build"
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,40 +3,17 @@
   "extends": [
     "github>openmcp-project/.github:renovate-config"
   ],
-  "git-submodules": {
-    "enabled": true
-  },
-  "minimumReleaseAge": "0 days",
-  "gitIgnoredAuthors": [
-    "github-actions[bot]@users.noreply.github.com"
-  ],
   "packageRules": [
     {
-      "description": "Automerge submodule update",
-      "automerge": true,
+      "description": "Group fluxcd updates in a single PR",
+      "matchDatasources": [
+        "go"
+      ],
+      "groupName": "fluxcd dependencies",
+      "groupSlug": "fluxcd-dependencies",
       "matchPackageNames": [
-        "hack/common"
+        "/^github\\.com/fluxcd/"
       ]
-    },
-    {
-      "description": "Update and automerge all components from openmcp-project immediately",
-      "matchPackageNames": [
-        "github.com/openmcp-project/*"
-      ],
-      "rebaseWhen": "auto",
-      "minimumReleaseAge": "0 days",
-      "automerge": true,
-      "enabled": true
-    },
-    {
-      "description": "Group all github.com/fluxcd go packages into one PR",
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchPackageNames": [
-        "github.com/fluxcd/**"
-      ],
-      "groupName": "fluxcd packages"
     }
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Moves `renovate.json` to `.github/renovate.json` and references the new org-level preset
- `extends`: recommended + best-practices + openssf-scorecard + pinGitHubActionDigests + rebaseStalePrs
- `postUpdateOptions`: gomodTidy
- golang `rangeStrategy: bump` rule
- `openmcp-project/build` group rule
- `openmcp-project` Go dependencies grouped into one PR

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```other dependency

```